### PR TITLE
40 各グループ個別ページのレイアウト整える in pages/groups/_groupId/index.vue

### DIFF
--- a/pages/groups/_groupId/index.vue
+++ b/pages/groups/_groupId/index.vue
@@ -58,7 +58,7 @@
                                                 <v-col cols="12">
                                                     <iframe height="400px" width="100%" v-bind:src="'https://web.microsoftstream.com/embed/video/'+streamVideoId+'?autoplay=false&showinfo=false'" allowfullscreen></iframe>
                                                 </v-col>
-                                                <v-card-text>※学校で配布されたMicrosoft365アカウントへのログインが必要です。</v-card-text>
+                                                <v-card-text>※学校で配布されたMicrosoftアカウントへのログインが必要です。</v-card-text>
                                                 <v-col cols="12">
                                                     <v-row justify="center">
                                                         <v-btn color="primary" v-bind:href="group.stream_url" target="_blank">再生できない場合（Streamで再生）＞</v-btn> 

--- a/pages/groups/_groupId/index.vue
+++ b/pages/groups/_groupId/index.vue
@@ -55,8 +55,14 @@
                                             <v-toolbar-title>{{group.title}}/{{group.groupname}}</v-toolbar-title>
                                             </v-toolbar>
                                             <v-row justify="center" align-content="center">
-                                                    <iframe height="1920px" width="1080px" v-bind:src="'https://web.microsoftstream.com/embed/video/'+streamVideoId+'?autoplay=false&showinfo=false'" allowfullscreen></iframe>
-                                                    <v-btn v-bind:href="group.stream_url" target="_blank">Streamで閲覧する＞</v-btn> 
+                                                <v-col cols="12">
+                                                    <iframe height="400px" width="100%" v-bind:src="'https://web.microsoftstream.com/embed/video/'+streamVideoId+'?autoplay=false&showinfo=false'" allowfullscreen></iframe>
+                                                </v-col>
+                                                <v-col cols="12">
+                                                    <v-row justify="center">
+                                                        <v-btn v-bind:href="group.stream_url" target="_blank">Streamで閲覧する＞</v-btn> 
+                                                    </v-row>
+                                                </v-col>
                                             </v-row>
                                         </v-card>
                                         </v-dialog>

--- a/pages/groups/_groupId/index.vue
+++ b/pages/groups/_groupId/index.vue
@@ -58,7 +58,7 @@
                                                 <v-col cols="12">
                                                     <iframe height="400px" width="100%" v-bind:src="'https://web.microsoftstream.com/embed/video/'+streamVideoId+'?autoplay=false&showinfo=false'" allowfullscreen></iframe>
                                                 </v-col>
-                                                <v-card-text>※学校で配布されたMicrosoftアカウントへのログインが必要です。</v-card-text>
+                                                <v-card-text>※映像鑑賞には，学校で配布されたMicrosoftアカウントへのログインが必要です。</v-card-text>
                                                 <v-col cols="12">
                                                     <v-row justify="center">
                                                         <v-btn color="primary" v-bind:href="group.stream_url" target="_blank">再生できない場合（Streamで再生）＞</v-btn> 

--- a/pages/groups/_groupId/index.vue
+++ b/pages/groups/_groupId/index.vue
@@ -80,9 +80,13 @@
                             v-model="dialog"
                             width="500">
                                 <template v-slot:activator="{ on, attrs }">
-                                    <v-card @click.stop="dialog = true">   
-                                    <v-card-title>{{event.title}}({{event.starts_at}}-{{event.ends_at}})</v-card-title>
-                                </v-card>
+                                    <v-row>
+                                        <v-col cols="12">
+                                            <v-card @click.stop="dialog = true">   
+                                                <v-card-title>{{event.title}}({{event.starts_at}}-{{event.ends_at}})</v-card-title>
+                                            </v-card>
+                                        </v-col>
+                                    </v-row>
                                 </template>
                                 <v-card>
                                     <v-card-title>この公演を選択しますか？</v-card-title>
@@ -107,7 +111,6 @@
                                 </v-card>
                                 
                         </v-dialog>
-
                         </div>
                     </div>
                 </v-col>

--- a/pages/groups/_groupId/index.vue
+++ b/pages/groups/_groupId/index.vue
@@ -7,126 +7,126 @@
             <v-row justify="center">
                 <v-col cols="10" sm="5">
                     <!--作品情報-->
-                    <div>
-                        
-                        <!--タイトル，団体，お気に入り，映像で鑑賞ボタン-->
-                        <v-card>
-                            <!--<v-img :src="group.thumbnail"></v-img>-->
-                            <v-card-title>{{group.title}}</v-card-title>
-                            <v-card-subtitle>{{group.groupname}}</v-card-subtitle>
-                            <!--
-                            お気に入り機能は未実装
-                            <v-btn icon>
-                                <v-icon>mdi-heart</v-icon>
-                            </v-btn> -->
+                    <!--タイトル，団体，お気に入り，映像で鑑賞ボタン-->
+                    <v-card>
+                        <!--<v-img :src="group.thumbnail"></v-img>-->
+                        <v-card-title>{{group.title}}</v-card-title>
+                        <v-card-subtitle>{{group.groupname}}</v-card-subtitle>
+                        <!--
+                        お気に入り機能は未実装
+                        <v-btn icon>
+                            <v-icon>mdi-heart</v-icon>
+                        </v-btn> -->
 
-                            <v-card-actions>
-                                <v-chip-group column>
-                                <v-chip v-for="tag in tags" disabled>
-                                    {{tag.tagname}}
-                                </v-chip>
-                                </v-chip-group>
-                            </v-card-actions>
+                        <v-card-actions>
+                            <v-chip-group column>
+                            <v-chip v-for="tag in tags" disabled>
+                                {{tag.tagname}}
+                            </v-chip>
+                            </v-chip-group>  
+                        </v-card-actions>
+                        <v-card-actions>
+                            <v-btn icon :href="group.twitter_url" target="_blank"><v-icon>mdi-twitter</v-icon></v-btn>
+                            <v-btn icon :href="group.instagram_url" target="_blank"><v-icon>mdi-instagram</v-icon></v-btn>
+                        </v-card-actions>
 
-                            <v-card-actions class="text-center">
-                                    <v-dialog
-                                    v-model="videoViewer"
-                                    fullscreen
+                        <v-card-actions class="text-center">
+                                <v-dialog
+                                v-model="videoViewer"
+                                fullscreen
+                                >
+                                <template v-slot:activator="{ on, attrs }">
+                                    <v-row justify="center">
+                                    <v-col>
+                                        <v-btn
+                                        color="primary"
+                                        dark
+                                        v-bind="attrs"
+                                        v-on="on"
+                                        rounded
+                                        >
+                                        <v-icon>mdi-play</v-icon>
+                                        映像で鑑賞
+                                        </v-btn>
+                                    </v-col>
+                                    </v-row>
+                                </template>
+                                <v-card dark>
+                                    <v-toolbar
+                                    dark
+                                    color="primary"
                                     >
+                                    <v-btn
+                                        icon
+                                        dark
+                                        @click="videoViewer = false"
+                                    >
+                                        <v-icon>mdi-close</v-icon>
+                                    </v-btn>
+                                    <v-toolbar-title>{{group.title}}/{{group.groupname}}</v-toolbar-title>
+                                    </v-toolbar>
+                                    <v-row justify="center" align-content="center">
+                                        <v-col cols="12">
+                                            <iframe height="400px" width="100%" v-bind:src="'https://web.microsoftstream.com/embed/video/'+streamVideoId+'?autoplay=false&showinfo=false'" allowfullscreen></iframe>
+                                        </v-col>
+                                        <v-card-text>※映像鑑賞には，学校で配布されたMicrosoftアカウントへのログインが必要です。</v-card-text>
+                                        <v-col cols="12">
+                                            <v-row justify="center">
+                                                <v-btn color="primary" v-bind:href="group.stream_url" target="_blank">再生できない場合（Streamで再生）＞</v-btn> 
+                                            </v-row>
+                                        </v-col>
+                                    </v-row>
+                                </v-card>
+                                </v-dialog>
+                        </v-card-actions>
+                    </v-card>
+            </v-col>
+            <v-col cols="10" sm="5">
+                <!--公演時間の選択-->
+                
+                    <v-card>
+                        <v-card-title>
+                        <v-icon>mdi-ticket</v-icon>
+                        観劇予約
+                        </v-card-title>
+                        <v-card-text>現地で見たい公演の整理券を取得できます。</v-card-text>
+                        <div v-for="event in events">
+                                <v-dialog
+                                v-model="dialog"
+                                width="500">
                                     <template v-slot:activator="{ on, attrs }">
                                         <v-row justify="center">
-                                        <v-col>
-                                            <v-btn
-                                            color="primary"
-                                            dark
-                                            v-bind="attrs"
-                                            v-on="on"
-                                            rounded
-                                            >
-                                            <v-icon>mdi-play</v-icon>
-                                            映像で鑑賞
-                                            </v-btn>
-                                        </v-col>
+                                            <v-col cols="11">
+                                                <v-card @click.stop="dialog = true">   
+                                                    <v-card-title>{{event.title}}({{event.starts_at}}-{{event.ends_at}})</v-card-title>
+                                                </v-card>
+                                            </v-col>
                                         </v-row>
                                     </template>
-                                    <v-card dark>
-                                        <v-toolbar
-                                        dark
-                                        color="primary"
-                                        >
-                                        <v-btn
-                                            icon
-                                            dark
-                                            @click="videoViewer = false"
-                                        >
-                                            <v-icon>mdi-close</v-icon>
-                                        </v-btn>
-                                        <v-toolbar-title>{{group.title}}/{{group.groupname}}</v-toolbar-title>
-                                        </v-toolbar>
-                                        <v-row justify="center" align-content="center">
-                                            <v-col cols="12">
-                                                <iframe height="400px" width="100%" v-bind:src="'https://web.microsoftstream.com/embed/video/'+streamVideoId+'?autoplay=false&showinfo=false'" allowfullscreen></iframe>
-                                            </v-col>
-                                            <v-card-text>※映像鑑賞には，学校で配布されたMicrosoftアカウントへのログインが必要です。</v-card-text>
-                                            <v-col cols="12">
-                                                <v-row justify="center">
-                                                    <v-btn color="primary" v-bind:href="group.stream_url" target="_blank">再生できない場合（Streamで再生）＞</v-btn> 
-                                                </v-row>
-                                            </v-col>
-                                        </v-row>
+                                    <v-card>
+                                        <v-card-title>この公演を選択しますか？</v-card-title>
+                                        <v-card-text>選択した公演:{{event.title}}({{event.starts_at}}-{{event.ends_at}})</v-card-text>
+                                    <v-card-actions>
+                                            <v-spacer></v-spacer>
+                                            <v-btn
+                                                color="primary"
+                                                text
+                                                @click="dialog = false"
+                                            >
+                                                はい
+                                            </v-btn>
+                                            <v-btn
+                                                color="red"
+                                                text
+                                                @click="dialog = false"
+                                            >
+                                                いいえ
+                                            </v-btn>
+                                        </v-card-actions>
                                     </v-card>
-                                    </v-dialog>
-                            </v-card-actions>
-                        </v-card>
-                    </div>
-                </v-col>
-                <v-col cols="10" sm="5">
-                    <!--公演時間の選択-->
-                    
-                        <v-card>
-                            <v-card-title>
-                            <v-icon>mdi-ticket</v-icon>
-                            観劇予約
-                            </v-card-title>
-                            <v-card-text>現地で見たい公演の整理券を取得できます。</v-card-text>
-                            <div v-for="event in events">
-                                    <v-dialog
-                                    v-model="dialog"
-                                    width="500">
-                                        <template v-slot:activator="{ on, attrs }">
-                                            <v-row justify="center">
-                                                <v-col cols="11">
-                                                    <v-card @click.stop="dialog = true">   
-                                                        <v-card-title>{{event.title}}({{event.starts_at}}-{{event.ends_at}})</v-card-title>
-                                                    </v-card>
-                                                </v-col>
-                                            </v-row>
-                                        </template>
-                                        <v-card>
-                                            <v-card-title>この公演を選択しますか？</v-card-title>
-                                            <v-card-text>選択した公演:{{event.title}}({{event.starts_at}}-{{event.ends_at}})</v-card-text>
-                                        <v-card-actions>
-                                                <v-spacer></v-spacer>
-                                                <v-btn
-                                                    color="primary"
-                                                    text
-                                                    @click="dialog = false"
-                                                >
-                                                    はい
-                                                </v-btn>
-                                                <v-btn
-                                                    color="red"
-                                                    text
-                                                    @click="dialog = false"
-                                                >
-                                                    いいえ
-                                                </v-btn>
-                                            </v-card-actions>
-                                        </v-card>
-                                    </v-dialog>
-                            </div>
-                       </v-card>
-                       
+                                </v-dialog>
+                        </div>
+                    </v-card>
                 </v-col>
             </v-row>
         </v-conteiner>

--- a/pages/groups/_groupId/index.vue
+++ b/pages/groups/_groupId/index.vue
@@ -74,46 +74,51 @@
                 </v-col>
                 <v-col cols="10" sm="5">
                     <!--公演時間の選択-->
-                    <div>
-                        <p>公演を選択してください</p>
-                        <div v-for="event in events">
-                        <v-dialog
-                            v-model="dialog"
-                            width="500">
-                                <template v-slot:activator="{ on, attrs }">
-                                    <v-row>
-                                        <v-col cols="12">
-                                            <v-card @click.stop="dialog = true">   
-                                                <v-card-title>{{event.title}}({{event.starts_at}}-{{event.ends_at}})</v-card-title>
-                                            </v-card>
-                                        </v-col>
-                                    </v-row>
-                                </template>
-                                <v-card>
-                                    <v-card-title>この公演を選択しますか？</v-card-title>
-                                    <v-card-text>選択した公演:{{event.title}}({{event.starts_at}}-{{event.ends_at}})</v-card-text>
-                                <v-card-actions>
-                                        <v-spacer></v-spacer>
-                                        <v-btn
-                                            color="primary"
-                                            text
-                                            @click="dialog = false"
-                                        >
-                                            はい
-                                        </v-btn>
-                                        <v-btn
-                                            color="red"
-                                            text
-                                            @click="dialog = false"
-                                        >
-                                            いいえ
-                                        </v-btn>
-                                    </v-card-actions>
-                                </v-card>
-                                
-                        </v-dialog>
-                        </div>
-                    </div>
+                    
+                        <v-card>
+                            <v-card-title>
+                            <v-icon>mdi-ticket</v-icon>
+                            観劇予約
+                            </v-card-title>
+                            <v-card-text>現地で見たい公演の整理券を取得できます。</v-card-text>
+                            <div v-for="event in events">
+                                    <v-dialog
+                                    v-model="dialog"
+                                    width="500">
+                                        <template v-slot:activator="{ on, attrs }">
+                                            <v-row justify="center">
+                                                <v-col cols="11">
+                                                    <v-card @click.stop="dialog = true">   
+                                                        <v-card-title>{{event.title}}({{event.starts_at}}-{{event.ends_at}})</v-card-title>
+                                                    </v-card>
+                                                </v-col>
+                                            </v-row>
+                                        </template>
+                                        <v-card>
+                                            <v-card-title>この公演を選択しますか？</v-card-title>
+                                            <v-card-text>選択した公演:{{event.title}}({{event.starts_at}}-{{event.ends_at}})</v-card-text>
+                                        <v-card-actions>
+                                                <v-spacer></v-spacer>
+                                                <v-btn
+                                                    color="primary"
+                                                    text
+                                                    @click="dialog = false"
+                                                >
+                                                    はい
+                                                </v-btn>
+                                                <v-btn
+                                                    color="red"
+                                                    text
+                                                    @click="dialog = false"
+                                                >
+                                                    いいえ
+                                                </v-btn>
+                                            </v-card-actions>
+                                        </v-card>
+                                    </v-dialog>
+                            </div>
+                       </v-card>
+                       
                 </v-col>
             </v-row>
         </v-conteiner>

--- a/pages/groups/_groupId/index.vue
+++ b/pages/groups/_groupId/index.vue
@@ -1,69 +1,116 @@
 <template>
     <v-app>
-        <v-btn icon fab>
+        <v-btn icon fab to="/groups/">
             <v-icon>mdi-chevron-left</v-icon>
         </v-btn>
+        <v-conteiner>
+            <v-row justify="center">
+                <v-col cols="10" sm="5">
+                    <!--作品情報-->
+                    <div>
+                        
+                        <!--タイトル，団体，お気に入り，映像で鑑賞ボタン-->
+                        <v-card>
+                            <!--<v-img :src="group.thumbnail"></v-img>-->
+                            <div>
+                                <v-card-title>{{group.title}}</v-card-title>
+                                <v-card-subtitle>{{group.groupname}}</v-card-subtitle>
+                                <!--
+                                <v-btn icon>
+                                    <v-icon>mdi-heart</v-icon>
+                                </v-btn> -->
+                                <v-card-actions class="text-center">
+                                        <v-dialog
+                                        v-model="videoViewer"
+                                        fullscreen
+                                        >
+                                        <template v-slot:activator="{ on, attrs }">
+                                            <v-row justify="center">
+                                            <v-col>
+                                                <v-btn
+                                                color="primary"
+                                                dark
+                                                v-bind="attrs"
+                                                v-on="on"
+                                                rounded
+                                                >
+                                                <v-icon>mdi-play</v-icon>
+                                                映像で鑑賞
+                                                </v-btn>
+                                            </v-col>
+                                            </v-row>
+                                        </template>
+                                        <v-card>
+                                            <v-toolbar
+                                            dark
+                                            color="primary"
+                                            >
+                                            <v-btn
+                                                icon
+                                                dark
+                                                @click="videoViewer = false"
+                                            >
+                                                <v-icon>mdi-close</v-icon>
+                                            </v-btn>
+                                            <v-toolbar-title>{{group.title}}/{{group.groupname}}</v-toolbar-title>
+                                            </v-toolbar>
+                                            <v-row justify="center" align-content="center">
+                                                    <iframe height="1920px" width="1080px" v-bind:src="'https://web.microsoftstream.com/embed/video/'+streamVideoId+'?autoplay=false&showinfo=false'" allowfullscreen></iframe>
+                                                    <v-btn v-bind:href="group.stream_url" target="_blank">Streamで閲覧する＞</v-btn> 
+                                            </v-row>
+                                        </v-card>
+                                        </v-dialog>
+                                </v-card-actions>
+                            </div>
+                        </v-card>
+                    </div>
+                </v-col>
+                <v-col cols="10" sm="5">
+                    <!--公演時間の選択-->
+                    <div>
+                        <p>公演を選択してください</p>
+                        <div v-for="event in events">
+                        <v-dialog
+                            v-model="dialog"
+                            width="500">
+                                <template v-slot:activator="{ on, attrs }">
+                                    <v-card @click.stop="dialog = true">   
+                                    <v-card-title>{{event.title}}({{event.starts_at}}-{{event.ends_at}})</v-card-title>
+                                </v-card>
+                                </template>
+                                <v-card>
+                                    <v-card-title>この公演を選択しますか？</v-card-title>
+                                    <v-card-text>選択した公演:{{event.title}}({{event.starts_at}}-{{event.ends_at}})</v-card-text>
+                                <v-card-actions>
+                                        <v-spacer></v-spacer>
+                                        <v-btn
+                                            color="primary"
+                                            text
+                                            @click="dialog = false"
+                                        >
+                                            はい
+                                        </v-btn>
+                                        <v-btn
+                                            color="red"
+                                            text
+                                            @click="dialog = false"
+                                        >
+                                            いいえ
+                                        </v-btn>
+                                    </v-card-actions>
+                                </v-card>
+                                
+                        </v-dialog>
 
-        <!--作品情報-->
-        <div>
-            <!--タイトル，団体，お気に入り，映像で鑑賞ボタン-->
-            <v-card>
-                <!--<v-img :src="group.thumbnail"></v-img>-->
-                <div>
-                    <v-card-title>{{group.title}}</v-card-title>
-                    <v-card-subtitle>{{group.groupname}}</v-card-subtitle>
-                    <v-btn icon>
-                        <v-icon>mdi-heart</v-icon>
-                    </v-btn>
-                    <v-btn color="light-blue" light>
-                        <v-icon>mdi-play</v-icon>
-                        <p>映像で鑑賞</p>
-                    </v-btn>
-                </div>
-                
-            </v-card>
-        </div>
+                        </div>
+                    </div>
+                </v-col>
+            </v-row>
+        </v-conteiner>
 
 
 
-        <!--公演時間の選択-->
-        <div>
-            <p>公演を選択してください</p>
-            <div v-for="event in events">
-               <v-dialog
-                v-model="dialog"
-                width="500">
-                    <template v-slot:activator="{ on, attrs }">
-                        <v-card @click.stop="dialog = true">   
-                        <v-card-title>{{event.title}}({{event.starts_at}}-{{event.ends_at}})</v-card-title>
-                    </v-card>
-                    </template>
-                    <v-card>
-                        <v-card-title>この公演を選択しますか？</v-card-title>
-                        <v-card-text>選択した公演:{{event.title}}({{event.starts_at}}-{{event.ends_at}})</v-card-text>
-                       <v-card-actions>
-                            <v-spacer></v-spacer>
-                            <v-btn
-                                color="primary"
-                                text
-                                @click="dialog = false"
-                            >
-                                はい
-                            </v-btn>
-                            <v-btn
-                                color="red"
-                                text
-                                @click="dialog = false"
-                            >
-                                いいえ
-                            </v-btn>
-                        </v-card-actions>
-                    </v-card>
-                    
-               </v-dialog>
-
-            </div>
-        </div>
+        
     </v-app>
 </template>
 
@@ -72,21 +119,27 @@ export default {
     data () {
       return {
         dialog: false,
+        videoViewer: false,
         group:{},
-        events:[]
+        events:[],
+        streamVideoId:[]
+        
       }
     },
     async asyncData({params,error,$axios}){
     let res_group;
+    let res_streamVideoId;
     let res_events;
     await $axios.get("/groups/"+params.groupId)
     .then(function (response) {
       console.log(response)
       res_group=response.data
+      res_streamVideoId=/[^/]*$/.exec(response.data.stream_url)[0]
     })
     .catch((e => {
         error({ statusCode:404,message: e.message })
     }))
+  
     await $axios.get("/groups/"+params.groupId+"/events")
     .then(function (response) {
       console.log(response)
@@ -95,7 +148,7 @@ export default {
     .catch((e => {
         error({ statusCode:404,message: e.message })
     }))
-    return {group:res_group,events:res_events}
+    return {group:res_group,events:res_events,streamVideoId:res_streamVideoId}
     }
 }
 </script>

--- a/pages/groups/_groupId/index.vue
+++ b/pages/groups/_groupId/index.vue
@@ -12,63 +12,71 @@
                         <!--タイトル，団体，お気に入り，映像で鑑賞ボタン-->
                         <v-card>
                             <!--<v-img :src="group.thumbnail"></v-img>-->
-                            <div>
-                                <v-card-title>{{group.title}}</v-card-title>
-                                <v-card-subtitle>{{group.groupname}}</v-card-subtitle>
-                                <!--
-                                <v-btn icon>
-                                    <v-icon>mdi-heart</v-icon>
-                                </v-btn> -->
-                                <v-card-actions class="text-center">
-                                        <v-dialog
-                                        v-model="videoViewer"
-                                        fullscreen
-                                        >
-                                        <template v-slot:activator="{ on, attrs }">
-                                            <v-row justify="center">
-                                            <v-col>
-                                                <v-btn
-                                                color="primary"
-                                                dark
-                                                v-bind="attrs"
-                                                v-on="on"
-                                                rounded
-                                                >
-                                                <v-icon>mdi-play</v-icon>
-                                                映像で鑑賞
-                                                </v-btn>
-                                            </v-col>
-                                            </v-row>
-                                        </template>
-                                        <v-card dark>
-                                            <v-toolbar
-                                            dark
-                                            color="primary"
-                                            >
+                            <v-card-title>{{group.title}}</v-card-title>
+                            <v-card-subtitle>{{group.groupname}}</v-card-subtitle>
+                            <!--
+                            お気に入り機能は未実装
+                            <v-btn icon>
+                                <v-icon>mdi-heart</v-icon>
+                            </v-btn> -->
+
+                            <v-card-actions>
+                                <v-chip-group column>
+                                <v-chip v-for="tag in tags" disabled>
+                                    {{tag.tagname}}
+                                </v-chip>
+                                </v-chip-group>
+                            </v-card-actions>
+
+                            <v-card-actions class="text-center">
+                                    <v-dialog
+                                    v-model="videoViewer"
+                                    fullscreen
+                                    >
+                                    <template v-slot:activator="{ on, attrs }">
+                                        <v-row justify="center">
+                                        <v-col>
                                             <v-btn
-                                                icon
-                                                dark
-                                                @click="videoViewer = false"
+                                            color="primary"
+                                            dark
+                                            v-bind="attrs"
+                                            v-on="on"
+                                            rounded
                                             >
-                                                <v-icon>mdi-close</v-icon>
+                                            <v-icon>mdi-play</v-icon>
+                                            映像で鑑賞
                                             </v-btn>
-                                            <v-toolbar-title>{{group.title}}/{{group.groupname}}</v-toolbar-title>
-                                            </v-toolbar>
-                                            <v-row justify="center" align-content="center">
-                                                <v-col cols="12">
-                                                    <iframe height="400px" width="100%" v-bind:src="'https://web.microsoftstream.com/embed/video/'+streamVideoId+'?autoplay=false&showinfo=false'" allowfullscreen></iframe>
-                                                </v-col>
-                                                <v-card-text>※映像鑑賞には，学校で配布されたMicrosoftアカウントへのログインが必要です。</v-card-text>
-                                                <v-col cols="12">
-                                                    <v-row justify="center">
-                                                        <v-btn color="primary" v-bind:href="group.stream_url" target="_blank">再生できない場合（Streamで再生）＞</v-btn> 
-                                                    </v-row>
-                                                </v-col>
-                                            </v-row>
-                                        </v-card>
-                                        </v-dialog>
-                                </v-card-actions>
-                            </div>
+                                        </v-col>
+                                        </v-row>
+                                    </template>
+                                    <v-card dark>
+                                        <v-toolbar
+                                        dark
+                                        color="primary"
+                                        >
+                                        <v-btn
+                                            icon
+                                            dark
+                                            @click="videoViewer = false"
+                                        >
+                                            <v-icon>mdi-close</v-icon>
+                                        </v-btn>
+                                        <v-toolbar-title>{{group.title}}/{{group.groupname}}</v-toolbar-title>
+                                        </v-toolbar>
+                                        <v-row justify="center" align-content="center">
+                                            <v-col cols="12">
+                                                <iframe height="400px" width="100%" v-bind:src="'https://web.microsoftstream.com/embed/video/'+streamVideoId+'?autoplay=false&showinfo=false'" allowfullscreen></iframe>
+                                            </v-col>
+                                            <v-card-text>※映像鑑賞には，学校で配布されたMicrosoftアカウントへのログインが必要です。</v-card-text>
+                                            <v-col cols="12">
+                                                <v-row justify="center">
+                                                    <v-btn color="primary" v-bind:href="group.stream_url" target="_blank">再生できない場合（Streamで再生）＞</v-btn> 
+                                                </v-row>
+                                            </v-col>
+                                        </v-row>
+                                    </v-card>
+                                    </v-dialog>
+                            </v-card-actions>
                         </v-card>
                     </div>
                 </v-col>
@@ -122,10 +130,6 @@
                 </v-col>
             </v-row>
         </v-conteiner>
-
-
-
-        
     </v-app>
 </template>
 
@@ -137,25 +141,28 @@ export default {
         videoViewer: false,
         group:{},
         events:[],
-        streamVideoId:[]
-        
+        streamVideoId:[],
+        tags:[]
       }
     },
     async asyncData({params,error,$axios}){
     let res_group;
     let res_streamVideoId;
     let res_events;
+    let res_tags;
     await $axios.get("/groups/"+params.groupId)
     .then(function (response) {
       console.log(response)
       res_group=response.data
+
+      //正規表現によって，groupの中に含まれる"stream_url"の末尾のスラッシュ（/）以降の文字列を取得
       res_streamVideoId=/[^/]*$/.exec(response.data.stream_url)[0]
     })
     .catch((e => {
         error({ statusCode:404,message: e.message })
     }))
   
-    await $axios.get("/groups/"+params.groupId+"/events")
+     await $axios.get("/groups/"+params.groupId+"/events")
     .then(function (response) {
       console.log(response)
       res_events=response.data
@@ -163,7 +170,18 @@ export default {
     .catch((e => {
         error({ statusCode:404,message: e.message })
     }))
-    return {group:res_group,events:res_events,streamVideoId:res_streamVideoId}
+
+    //groupと結びついたTagを取得
+    await $axios.get("/groups/"+params.groupId+"/tags")
+    .then(function (response) {
+      console.log(response)
+      res_tags=response.data
+    })
+    .catch((e => {
+        error({ statusCode:404,message: e.message })
+    }))
+
+    return {group:res_group,events:res_events,streamVideoId:res_streamVideoId,tags:res_tags}
     }
 }
 </script>

--- a/pages/groups/_groupId/index.vue
+++ b/pages/groups/_groupId/index.vue
@@ -40,7 +40,7 @@
                                             </v-col>
                                             </v-row>
                                         </template>
-                                        <v-card>
+                                        <v-card dark>
                                             <v-toolbar
                                             dark
                                             color="primary"
@@ -58,9 +58,10 @@
                                                 <v-col cols="12">
                                                     <iframe height="400px" width="100%" v-bind:src="'https://web.microsoftstream.com/embed/video/'+streamVideoId+'?autoplay=false&showinfo=false'" allowfullscreen></iframe>
                                                 </v-col>
+                                                <v-card-text>※学校で配布されたMicrosoft365アカウントへのログインが必要です。</v-card-text>
                                                 <v-col cols="12">
                                                     <v-row justify="center">
-                                                        <v-btn v-bind:href="group.stream_url" target="_blank">Streamで閲覧する＞</v-btn> 
+                                                        <v-btn color="primary" v-bind:href="group.stream_url" target="_blank">再生できない場合（Streamで再生）＞</v-btn> 
                                                     </v-row>
                                                 </v-col>
                                             </v-row>

--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -7,6 +7,7 @@
   <v-col
   cols="12"
   md="4"
+  sm="6"
   calss="my-1"
   v-for="group in groups"
   >
@@ -39,6 +40,7 @@
       >
         もっと見る
       </v-btn>
+      
     </v-card-actions>
   </v-card>
   </v-col>


### PR DESCRIPTION
## Done
- Stream動画を埋め込む
- Streamサイトへのリンクを貼る
- 公演一覧を表示する
- 大きなウィンドウサイズの場合に2段組にする
- タグの表示
- SNSアカウントを表示する

## ToDo
- 整理券の表示
   - 公演名（第○公演），時間
　　- 取得できない整理券はdisabled
   - 取得できない場合は，①売り切れ②同時間帯の整理券を取得済　の最低2パターン
   - 空席情報は「🟣🔺❌」で表示
- 整理券を取得できるようにする
（dataの中のプロパティ名"dialog"をそのまま使うと，整理券取得の際に複数のモーダルウィンドウが同時に出現するので，プロパティ名を"event_1"のように，各公演ごとに設定する必要がある点に注意）
- 埋め込みの仕様上，モーダルウィンドウを閉じてもStreamの再生が続く問題を解決する
- 写真（サムネイル）を表示する
- timetable_nameを取得し，公演名として表示する（axiosを使ったデータ取得から書かなきゃいけない）