### PR TITLE
/tickets/ 持ってる整理券一覧のデザイン改良

### DIFF
--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -3,6 +3,20 @@
     <v-container name="ticket_container">
       <v-row justify="center" align-content="center">
         <v-col cols="12" sm="6" lg="6">
+          <!--現在時刻を表示・現在時刻を取得するとv-progress-linearが正常に動作しないため非表示-->
+          <!--
+            <v-chip v-if="time" label class="ma-1"
+              >{{ time }} <span class="text-h5">{{ seconds }} </span></v-chip
+            >
+            -->
+
+          <!--再読み込みボタン-->
+          <div class="text-center pa-1">
+            <v-btn class="mx-1 my-1" color="primary" @click="fetchTicket()"
+              ><v-icon>mdi-reload</v-icon>再読み込み</v-btn
+            >
+          </div>
+
           <!--校内への入場処理が行われていない場合に，入場処理を促すメッセージと処理用のQRコードを表示-->
           <!--ここのデザインをもうちょっと可愛く出来ないかな-->
           <v-card
@@ -46,20 +60,6 @@
             </v-card-text>
             -->
           </v-card>
-
-          <!--現在時刻を表示・現在時刻を取得するとv-progress-linearが正常に動作しないため非表示-->
-          <!--
-            <v-chip v-if="time" label class="ma-1"
-              >{{ time }} <span class="text-h5">{{ seconds }} </span></v-chip
-            >
-            -->
-
-          <!--再読み込みボタン-->
-          <div class="text-center pa-1">
-            <v-btn class="mx-1 my-1" color="primary" @click="fetchTicket()"
-              ><v-icon>mdi-reload</v-icon>再読み込み</v-btn
-            >
-          </div>
 
           <!--
             不要だと判断し，業務連絡を非表示

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -14,7 +14,8 @@
           >
             <v-card-title>まずは日比谷高校に入場しよう！</v-card-title>
             <v-card-text>
-              【保護者】校門にいる係生徒に以下のQRコードを提示してください。保護者のみなさんが整理券を取得・使用するには校内への入場が必要です。
+              【保護者】校門にいる係生徒に以下のQRコードまたはUser
+              IDを提示してください。保護者のみなさんが整理券を取得・使用するには校内への入場が必要です。
             </v-card-text>
             <v-card-text>
               【日比谷生】開場時間になると操作できるようになります。校門での入校処理は不要です。
@@ -49,7 +50,7 @@
           <!--現在時刻を表示-->
           <div class="text-center pa-1">
             <v-chip v-if="time" label class="ma-1"
-              >{{ time }} <span class="text-h5">{{ second }} </span></v-chip
+              >{{ time }} <span class="text-h5">{{ seconds }} </span></v-chip
             >
             <v-btn class="mx-1 my-1" color="primary" @click="fetchTicket()"
               ><v-icon>mdi-reload</v-icon>再読み込み</v-btn
@@ -118,9 +119,9 @@
                       >
                         <span class="text-h5"
                           ><v-icon>mdi-clock-time-nine</v-icon
-                          >{{ TimeFormatter(ticketInfo.event.starts_at) }}</span
+                          >{{ timeFormatter(ticketInfo.event.starts_at) }}</span
                         >
-                        -{{ TimeFormatter(ticketInfo.event.ends_at) }}
+                        -{{ timeFormatter(ticketInfo.event.ends_at) }}
                       </v-list-item-subtitle>
                       <v-list-item-subtitle
                         class="mb-2 grey--text text--darken-2"
@@ -139,7 +140,7 @@
                             new Date(ticketInfo.event.ends_at)
                           )
                         "
-                        color="green"
+                        color="primary"
                         outlined
                         label
                         ><v-icon>mdi-theater</v-icon>開場中</v-chip
@@ -151,7 +152,7 @@
                         label
                         ><v-icon>mdi-check</v-icon>公演終了</v-chip
                       >
-                      <v-chip v-else color="primary" outlined label>
+                      <v-chip v-else color="green" outlined label>
                         <v-icon>mdi-account-clock</v-icon>開場前
                       </v-chip>
                     </div>
@@ -248,7 +249,7 @@ type Data = {
   success_message: string
   error_message: string
   time: string
-  second: string
+  seconds: string
 }
 export default Vue.extend({
   name: 'UsersTicketsPage',
@@ -268,7 +269,7 @@ export default Vue.extend({
       success_message: '',
       error_message: '',
       time: '',
-      second: '',
+      seconds: '',
     }
   },
   head: {
@@ -301,7 +302,7 @@ export default Vue.extend({
       const dateTime = date + ' ' + time + ':'
       const seconds = today.getSeconds()
       this.time = dateTime
-      this.second = seconds + ''
+      this.seconds = seconds + ''
     },
 
     // upNext（開演X分前から終演時刻まで）かどうかを判定するmethod
@@ -368,7 +369,7 @@ export default Vue.extend({
       })
       this.tickets = ticketInfos
     },
-    TimeFormatter(inputDate: string) {
+    timeFormatter(inputDate: string) {
       const d = new Date(inputDate)
       return (
         /*
@@ -383,7 +384,7 @@ export default Vue.extend({
         d.getMinutes().toString().padStart(2, '0')
       )
     },
-    DateFormatter(inputDate: string) {
+    dateFormatter(inputDate: string) {
       const d = new Date(inputDate)
       return d.getMonth() + 1 + '/' + d.getDate()
     },

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -42,7 +42,7 @@
             受付担当者は公演時間と入場人数を確認してください
           </p>
 
-          <!--この部分にUp-Nextを表示; v-if="isUpNext"で条件に合致するか調査-->
+          <!--この部分にUp-Nextを表示; v-if="isUpNext"で条件に合致するか調査
           <v-card>
             <v-card-title>次はこちら</v-card-title>
             <v-card
@@ -53,7 +53,7 @@
               <p>{{ ticketInfo.event.eventname }}</p>
             </v-card>
           </v-card>
-
+-->
           <!--これより下に表示されるv-cardは，v-if="!isUpNext"のみ-->
           <v-card
             v-for="ticketInfo in tickets"

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -40,14 +40,29 @@
             <v-chip v-if="time" label class="ma-1"
               >{{ time }} <span class="text-h5">{{ second }} </span></v-chip
             >
+          </div>
+
+          <!--
             <p class="mx-1 my-0 py-0 text-caption grey--text">
               この画面を観劇したいクラスの受付担当に見せてください
             </p>
             <p class="mx-1 my-0 py-0 text-caption grey--text">
               受付担当者は公演時間と入場人数を確認してください
             </p>
-          </div>
-          <v-card flat>
+            -->
+          <v-card v-if="tickets.length == 0" class="ma-1 pa-2">
+            <div>
+              <v-card-title>まだ整理券を取得していません</v-card-title>
+              <v-card-actions>
+                <v-btn :href="'/groups'" block
+                  >次に見たい公演を探しに行きましょう✨</v-btn
+                >
+              </v-card-actions>
+            </div>
+          </v-card>
+
+          <!--取得した整理券一覧-->
+          <v-card flat class="ma-1">
             <v-expansion-panels>
               <v-expansion-panel
                 v-for="ticketInfo in tickets"
@@ -169,12 +184,7 @@
               </v-card-actions>
             </v-card>
           </v-dialog>
-          <div v-if="tickets.length == 0" class="pa-3">
-            <p>ここに表示するものはありません</p>
-            <a href="/groups" class="amber--text text--darken-4"
-              >次に見たい公演を探しに行きましょう✨</a
-            >
-          </div>
+
           <v-btn class="mx-1 my-3" color="primary" @click="fetchTicket()"
             ><v-icon>mdi-reload</v-icon>再読み込み</v-btn
           >

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -155,6 +155,7 @@
                       max-width="100px"
                       height="165px"
                       class="mr-2"
+                      contain
                     ></v-img>
                     <div class="ma-2">
                       <!--取得した整理券の情報を表示-->

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -1,9 +1,10 @@
 <template>
   <v-app>
-    <v-container name="ticket_container" class="ma-0 pa-0">
-      <v-row class="ma-0 pa-0" justify="center" align-content="center">
-        <v-col col="6" md="6" sm="12">
+    <v-container name="ticket_container">
+      <v-row justify="center" align-content="center">
+        <v-col cols="12" sm="6" lg="6">
           <!--校内への入場処理が行われていない場合に，入場処理を促すメッセージと処理用のQRコードを表示-->
+          <!--ここのデザインをもうちょっと可愛く出来ないかな-->
           <v-card
             v-if="
               !(
@@ -12,14 +13,13 @@
               )
             "
           >
-            <v-card-title>まずは日比谷高校に入場しよう！</v-card-title>
-            <v-card-text>
-              【保護者】校門にいる係生徒に以下のQRコードまたはUser
-              IDを提示してください。保護者のみなさんが整理券を取得・使用するには校内への入場が必要です。
-            </v-card-text>
-            <v-card-text>
-              【日比谷生】開場時間になると操作できるようになります。校門での入校処理は不要です。
-            </v-card-text>
+            <v-card-title class="text-h5">🥳星陵祭へようこそ！</v-card-title>
+            <v-card-subtitle class="text-h6"
+              >校門でこの画面をご提示ください。</v-card-subtitle
+            >
+            <v-card-text
+              >※日比谷生の入場手続きは不要です。そのままお待ちください。</v-card-text
+            >
             <v-img
               class="mx-auto my-0"
               style="display: block"
@@ -53,6 +53,8 @@
               >{{ time }} <span class="text-h5">{{ seconds }} </span></v-chip
             >
             -->
+
+          <!--再読み込みボタン-->
           <div class="text-center pa-1">
             <v-btn class="mx-1 my-1" color="primary" @click="fetchTicket()"
               ><v-icon>mdi-reload</v-icon>再読み込み</v-btn
@@ -101,7 +103,6 @@
                   new Date(ticketInfo.event.ends_at)
                 )
               "
-              class="pa-3 ma-3"
             >
               <v-card-title class="mb-2"
                 ><v-icon>mdi-ticket</v-icon>整理券
@@ -115,7 +116,7 @@
               >
               <v-divider></v-divider>
 
-              <v-card-title class="text-h7 pt-1">
+              <v-card-title class="text-h7">
                 {{ ticketInfo.group.title }}
               </v-card-title>
               <v-card-subtitle class="pb-0">
@@ -152,13 +153,19 @@
               <v-img
                 v-if="ticketInfo.group.public_thumbnail_image_url != null"
                 :src="ticketInfo.group.public_thumbnail_image_url"
-                max-width="100%"
-                height="130px"
+                width="100%"
+                max-height="130px"
               ></v-img>
             </v-card>
           </div>
+        </v-col>
+        <v-col cols="12" sm="6" lg="6">
           <!--取得した整理券一覧-->
-          <v-card flat class="ma-1">
+          <v-card v-if="tickets.length !== 0">
+            <v-card-title
+              ><v-icon>mdi-ticket-account</v-icon>あなたの整理券</v-card-title
+            >
+
             <v-expansion-panels>
               <v-expansion-panel
                 v-for="ticketInfo in tickets"

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -45,6 +45,7 @@
           <v-card
             v-for="ticketInfo in tickets"
             :key="ticketInfo.ticket.id"
+            class="ma-2 pa-2"
             max-width="100%"
             outlined
             rounded
@@ -52,22 +53,25 @@
           >
             <v-list-item two-line>
               <v-list-item-content>
-                <!--
-                <v-img
-                  v-if="ticketInfo.group.public_thumbnail_image_url != null"
-                  :src="ticketInfo.group.public_thumbnail_image_url"
-                  max-width="20px"
-                ></v-img>
-              -->
-                <v-list-item-title class="text-h7 mb-1">
-                  【{{ ticketInfo.event.eventname }}】{{
-                    ticketInfo.group.title
-                  }}
-                </v-list-item-title>
-                <v-list-item-subtitle>
-                  {{ ticketInfo.group.groupname }}</v-list-item-subtitle
-                ></v-list-item-content
-              >
+                <div class="d-flex flex-no-wrap">
+                  <v-img
+                    v-if="ticketInfo.group.public_thumbnail_image_url != null"
+                    :src="ticketInfo.group.public_thumbnail_image_url"
+                    max-width="40px"
+                    class="mx-2"
+                  ></v-img>
+                  <div>
+                    <v-list-item-title class="text-h7 mb-1">
+                      【{{ ticketInfo.event.eventname }}】{{
+                        ticketInfo.group.title
+                      }}
+                    </v-list-item-title>
+                    <v-list-item-subtitle>
+                      {{ ticketInfo.group.groupname }}</v-list-item-subtitle
+                    >
+                  </div>
+                </div>
+              </v-list-item-content>
               <v-card-actions>
                 <v-btn
                   icon
@@ -84,48 +88,55 @@
             <v-expand-transition>
               <div v-show="ticketInfo.detailShow">
                 <v-divider></v-divider>
-                <v-card-actions>
-                  <v-btn
-                    class="text-body-2"
-                    :href="'/groups/' + ticketInfo.group.id"
-                    >詳細を見る
-                  </v-btn>
-                </v-card-actions>
+
                 <v-card-text>
-                  <p class="text-body-2">
-                    <v-icon>mdi-clock-time-nine</v-icon
-                    ><span class="grey--text text--darken-2">公演:</span
-                    >{{ DateFormatter(ticketInfo.event.starts_at) }} -
-                    {{ DateFormatter(ticketInfo.event.ends_at) }}
-                  </p>
-                  <p class="text-body-2">
-                    <v-icon>mdi-account-supervisor</v-icon
-                    ><span class="grey--text text--darken-2">人数:</span
-                    >{{ ticketInfo.ticket.person }}
-                  </p>
-                </v-card-text>
-                <v-card-actions
-                  ><v-btn color="error" @click="selectCancelTicket(ticketInfo)">
-                    <v-icon>mdi-close</v-icon>
-                    キャンセル
-                  </v-btn></v-card-actions
-                >
-                <v-card-text>
-                  <p class="text-body-2 grey--text">
+                  <div class="d-flex flex-no-wrap">
+                    <p class="text-body-2">
+                      <v-icon>mdi-clock-time-nine</v-icon
+                      ><span class="grey--text text--darken-2">公演:</span>
+                      <span class="text-h5">{{
+                        DateFormatter(ticketInfo.event.starts_at)
+                      }}</span>
+                      -{{ DateFormatter(ticketInfo.event.ends_at) }}
+                    </p>
+                    <v-spacer></v-spacer>
+                    <p class="text-body-2">
+                      <v-icon>mdi-account-supervisor</v-icon
+                      ><span class="grey--text text--darken-2">人数:</span
+                      ><span class="text-h5">{{
+                        ticketInfo.ticket.person
+                      }}</span>
+                    </p>
+                  </div>
+                  <p class="text-body-2 grey--text mb-0">
                     ID: {{ ticketInfo.ticket.id }}
                   </p>
                 </v-card-text>
+                <v-card-actions>
+                  <v-btn :href="'/groups/' + ticketInfo.group.id"
+                    >公演詳細
+                  </v-btn>
+                  <v-spacer></v-spacer>
+                  <v-btn color="error" @click="selectCancelTicket(ticketInfo)">
+                    <v-icon>mdi-close</v-icon>
+                    整理券をキャンセル
+                  </v-btn>
+                </v-card-actions>
               </div>
             </v-expand-transition>
           </v-card>
 
+          <!--キャンセルの有無を問うダイアログ-->
           <v-dialog v-if="selectedTicket" v-model="cancelDialog">
             <v-card>
               <v-card-title class="text-h5">
                 本当にキャンセルしますか？
               </v-card-title>
+
               <v-card-title>
-                {{ selectedTicket.group.title }}
+                【{{ selectedTicket.event.eventname }}】{{
+                  selectedTicket.group.title
+                }}
               </v-card-title>
               <v-card-subtitle>{{
                 selectedTicket.group.groupname
@@ -133,10 +144,10 @@
               <v-card-text>この操作は取り消せません</v-card-text>
               <v-card-actions>
                 <v-spacer></v-spacer>
-                <v-btn color="primary" @click="cancelDialog = false"
-                  >いいえ</v-btn
+                <v-btn text @click="cancelDialog = false">いいえ</v-btn>
+                <v-btn color="error" @click="CancelTicket(selectedTicket)"
+                  >はい</v-btn
                 >
-                <v-btn text @click="CancelTicket(selectedTicket)">はい</v-btn>
               </v-card-actions>
             </v-card>
           </v-dialog>
@@ -254,11 +265,13 @@ export default Vue.extend({
     DateFormatter(inputDate: string) {
       const d = new Date(inputDate)
       return (
+        /*
         d.getMonth() +
         1 +
         '月' +
         d.getDate() +
         '日 ' +
+        */
         d.getHours().toString().padStart(2, '0') +
         ':' +
         d.getMinutes().toString().padStart(2, '0')

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -148,6 +148,7 @@
                     </v-btn>
                     <v-spacer></v-spacer>
                     <v-btn
+                      v-if="!isUsed(new Date(ticketInfo.event.ends_at))"
                       color="error"
                       @click="selectCancelTicket(ticketInfo)"
                     >

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -44,32 +44,7 @@
             <v-card-text
               >User ID:{{ $auth.user?.oid ?? $auth.user?.sub }}</v-card-text
             >
-
-            <!--
-              ユーザIDの表示/非表示切り替えは不要と判断し以下の実装を削除
-            <v-card-text class="mx-3 my-1">
-              <a
-                class="text-subtitle-2"
-                @click="display_userid = !display_userid"
-                >ユーザーIDを表示: </a
-              ><span v-show="display_userid"
-                >{{ $auth.user?.oid ?? $auth.user?.sub }}
-                </span
-              >
-            
-            </v-card-text>
-            -->
           </v-card>
-
-          <!--
-            不要だと判断し，業務連絡を非表示
-            <p class="mx-1 my-0 py-0 text-caption grey--text">
-              この画面を観劇したいクラスの受付担当に見せてください
-            </p>
-            <p class="mx-1 my-0 py-0 text-caption grey--text">
-              受付担当者は公演時間と入場人数を確認してください
-            </p>
-          -->
 
           <!--整理券未取得の場合に，「探す」タブへ誘導-->
           <v-card
@@ -147,7 +122,7 @@
               </v-card-subtitle>
               <v-progress-linear
                 indeterminate
-                height="10px"
+                height="15px"
                 color="teal"
               ></v-progress-linear>
               <v-img

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -34,120 +34,114 @@
               >
             </div>
           </v-card>
-          <div class="my-3" />
 
-          <p class="mx-1 my-0 py-0 text-caption grey--text">
-            この画面を観劇したいクラスの受付担当に見せてください
-          </p>
-          <p class="mx-1 my-0 py-0 text-caption grey--text">
-            受付担当者は公演時間と入場人数を確認してください
-          </p>
+          <!--現在の時刻を表示-->
           <div class="text-center">
             <v-chip v-if="time" label class="ma-1"
               >{{ time }} <span class="text-h5">{{ second }} </span></v-chip
             >
+            <p class="mx-1 my-0 py-0 text-caption grey--text">
+              この画面を観劇したいクラスの受付担当に見せてください
+            </p>
+            <p class="mx-1 my-0 py-0 text-caption grey--text">
+              受付担当者は公演時間と入場人数を確認してください
+            </p>
           </div>
-          <v-card
-            v-for="ticketInfo in tickets"
-            :key="ticketInfo.ticket.id"
-            class="ma-1 pa-1"
-            max-width="100%"
-            outlined
-            rounded
-            elevation="2"
-          >
-            <!--公演の開始15分前-公演終了までの場合み表示されるdiv-->
-
-            <v-list-item two-line>
-              <v-list-item-content>
-                <div class="d-flex flex-no-wrap">
-                  <v-img
-                    v-if="ticketInfo.group.public_thumbnail_image_url != null"
-                    :src="ticketInfo.group.public_thumbnail_image_url"
-                    max-width="60px"
-                    height="100px"
-                    class="ma-2"
-                  ></v-img>
-                  <div class="ma-2">
-                    <v-list-item-subtitle
-                      >{{ ticketInfo.event.eventname }}・{{
-                        DateFormatter(ticketInfo.event.starts_at)
-                      }}</v-list-item-subtitle
-                    >
-                    <v-list-item-title class="text-h7">
-                      {{ ticketInfo.group.title }}
-                    </v-list-item-title>
-                    <v-list-item-subtitle class="mb-4">
-                      {{ ticketInfo.group.groupname }}</v-list-item-subtitle
-                    >
-                    <v-chip
-                      v-if="
-                        isUpNext(
-                          new Date(ticketInfo.event.starts_at),
-                          new Date(ticketInfo.event.ends_at)
-                        )
-                      "
-                      color="primary"
-                      outlined
-                      label
-                      ><v-icon>mdi-theater</v-icon>開場中</v-chip
-                    >
-                  </div>
-                </div>
-              </v-list-item-content>
-
-              <v-card-actions>
-                <v-btn
-                  icon
-                  @click="ticketInfo.detailShow = !ticketInfo.detailShow"
-                >
-                  <v-icon>{{
-                    ticketInfo.detailShow
-                      ? 'mdi-chevron-up'
-                      : 'mdi-chevron-down'
-                  }}</v-icon>
-                </v-btn>
-              </v-card-actions>
-            </v-list-item>
-            <v-expand-transition>
-              <div v-show="ticketInfo.detailShow" class="ma-2">
-                <v-divider></v-divider>
-
-                <v-card-text>
-                  <div class="d-flex flex-no-wrap">
-                    <p class="text-body-2">
-                      <v-icon>mdi-clock-time-nine</v-icon
-                      ><span class="grey--text text--darken-2">公演 </span>
-                      <span class="text-h5">{{
-                        TimeFormatter(ticketInfo.event.starts_at)
-                      }}</span>
-                      -{{ TimeFormatter(ticketInfo.event.ends_at) }}
+          <v-card flat>
+            <v-expansion-panels>
+              <v-expansion-panel
+                v-for="ticketInfo in tickets"
+                :key="ticketInfo.ticket.id"
+                focusable
+              >
+                <v-expansion-panel-header>
+                  <v-list-item two-line>
+                    <div class="d-flex flex-no-wrap">
+                      <v-img
+                        v-if="
+                          ticketInfo.group.public_thumbnail_image_url != null
+                        "
+                        :src="ticketInfo.group.public_thumbnail_image_url"
+                        max-width="60px"
+                        height="100px"
+                        class="ma-2"
+                      ></v-img>
+                      <div class="ma-2">
+                        <v-list-item-subtitle
+                          >{{ ticketInfo.event.eventname }}・{{
+                            DateFormatter(ticketInfo.event.starts_at)
+                          }}</v-list-item-subtitle
+                        >
+                        <v-list-item-title class="text-h7">
+                          {{ ticketInfo.group.title }}
+                        </v-list-item-title>
+                        <v-list-item-subtitle class="mb-4">
+                          {{ ticketInfo.group.groupname }}</v-list-item-subtitle
+                        >
+                        <v-chip
+                          v-if="isUsed(new Date(ticketInfo.event.ends_at))"
+                          color="error"
+                          outlined
+                          label
+                          ><v-icon>mdi-check</v-icon>公演終了</v-chip
+                        >
+                        <v-chip
+                          v-if="
+                            isUpNext(
+                              new Date(ticketInfo.event.starts_at),
+                              new Date(ticketInfo.event.ends_at)
+                            )
+                          "
+                          color="primary"
+                          outlined
+                          label
+                          ><v-icon>mdi-theater</v-icon>開場中</v-chip
+                        >
+                      </div>
+                    </div>
+                  </v-list-item>
+                </v-expansion-panel-header>
+                <v-expansion-panel-content>
+                  <v-divider></v-divider>
+                  <v-card-text>
+                    <div class="d-flex flex-no-wrap">
+                      <p class="text-body-2">
+                        <v-icon>mdi-clock-time-nine</v-icon
+                        ><span class="grey--text text--darken-2">公演 </span>
+                        <span class="text-h5">{{
+                          TimeFormatter(ticketInfo.event.starts_at)
+                        }}</span>
+                        -{{ TimeFormatter(ticketInfo.event.ends_at) }}
+                      </p>
+                      <v-spacer></v-spacer>
+                      <p class="text-body-2">
+                        <v-icon>mdi-account-supervisor</v-icon
+                        ><span class="grey--text text--darken-2">人数 </span
+                        ><span class="text-h5">{{
+                          ticketInfo.ticket.person
+                        }}</span>
+                      </p>
+                    </div>
+                    <p class="text-body-2 grey--text mb-0">
+                      ID: {{ ticketInfo.ticket.id }}
                     </p>
+                  </v-card-text>
+                  <v-card-actions>
+                    <v-btn :href="'/groups/' + ticketInfo.group.id"
+                      >公演詳細
+                    </v-btn>
                     <v-spacer></v-spacer>
-                    <p class="text-body-2">
-                      <v-icon>mdi-account-supervisor</v-icon
-                      ><span class="grey--text text--darken-2">人数 </span
-                      ><span class="text-h5">{{
-                        ticketInfo.ticket.person
-                      }}</span>
-                    </p>
-                  </div>
-                  <p class="text-body-2 grey--text mb-0">
-                    ID: {{ ticketInfo.ticket.id }}
-                  </p>
-                </v-card-text>
-                <v-card-actions>
-                  <v-btn :href="'/groups/' + ticketInfo.group.id"
-                    >公演詳細
-                  </v-btn>
-                  <v-spacer></v-spacer>
-                  <v-btn color="error" @click="selectCancelTicket(ticketInfo)">
-                    <v-icon>mdi-close</v-icon>
-                    整理券をキャンセル
-                  </v-btn>
-                </v-card-actions>
-              </div>
-            </v-expand-transition>
+                    <v-btn
+                      color="error"
+                      @click="selectCancelTicket(ticketInfo)"
+                    >
+                      <v-icon>mdi-close</v-icon>
+                      整理券をキャンセル
+                    </v-btn>
+                  </v-card-actions>
+                </v-expansion-panel-content>
+              </v-expansion-panel>
+            </v-expansion-panels>
           </v-card>
 
           <!--キャンセルの有無を問うダイアログ-->
@@ -204,7 +198,6 @@ type TicketInfo = {
   group: Group
   event: Event
   ticket: Ticket
-  detailShow: boolean
 }
 type Data = {
   groups: Group[]
@@ -293,6 +286,19 @@ export default Vue.extend({
         return false
       }
     },
+
+    // 整理券が使用されたかどうか判定するmethod（時間だけで管理している）
+    isUsed: function (end: Date) {
+      const date = new Date()
+      const currentTime: Date = new Date(date.getTime())
+
+      // 「 終演時刻<現在時刻」を判定
+      if (end < currentTime) {
+        return true
+      } else {
+        return false
+      }
+    },
     async fetchTicket() {
       const tickets: Ticket[] = await this.$axios.$get('/users/me/tickets')
 
@@ -308,7 +314,6 @@ export default Vue.extend({
           group,
           event,
           ticket,
-          detailShow: false,
         }
         ticketInfos.push(ticketInfo)
       }

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -216,6 +216,13 @@ export default Vue.extend({
   head: {
     title: '整理券',
   },
+  computed: {
+    /* 
+    ここに，
+    （現在時刻-15分）＜ticketInfo.event.starts_at && ticketInfo.event.ends_at<（現在時刻）
+    となるようなeventをupnNext= []の中に入れる処理を書く
+    */
+  },
   async created() {
     this.fetchTicket()
     try {

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -74,7 +74,7 @@
                 :key="ticketInfo.ticket.id"
                 focusable
               >
-                <v-expansion-panel-header>
+                <v-expansion-panel-header class="pa-1">
                   <v-list-item>
                     <v-img
                       v-if="ticketInfo.group.public_thumbnail_image_url != null"
@@ -138,10 +138,10 @@
                     </div>
                   </v-list-item>
                 </v-expansion-panel-header>
-                <v-expansion-panel-content>
+                <v-expansion-panel-content class="pa-1">
                   <v-divider></v-divider>
                   <v-card-text>
-                    <p class="text-body-2 grey--text mb-0">
+                    <p class="text-body-2 grey--text">
                       ID: {{ ticketInfo.ticket.id }}
                     </p>
                   </v-card-text>

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -88,6 +88,7 @@
             </div>
           </v-card>
 
+          <!--開場中の整理券がある場合に上部に大きく表示-->
           <div
             v-for="ticketInfo in tickets"
             :key="ticketInfo.ticket.id"
@@ -114,7 +115,7 @@
               >
               <v-divider></v-divider>
 
-              <v-card-title class="text-h7">
+              <v-card-title class="text-h7 pt-1">
                 {{ ticketInfo.group.title }}
               </v-card-title>
               <v-card-subtitle class="pb-0">
@@ -122,12 +123,22 @@
               >
 
               <v-card-subtitle class="grey--text text--darken-2">
+                <!--日付：画面がごちゃごちゃするため省略．1日目の整理券を画面収録して2日目に使う人が現れるなどしたら，実装が必要-->
+                <!--
+                <span class="text-h3"
+                  ><v-icon>mdi-calendar</v-icon
+                  >{{ dateFormatter(ticketInfo.event.starts_at) }}</span
+                >
+                -->
+                <v-spacer></v-spacer>
+                <!--上演時刻-->
                 <span class="text-h3"
                   ><v-icon>mdi-clock-time-nine</v-icon
                   >{{ timeFormatter(ticketInfo.event.starts_at) }}</span
                 >
                 -{{ timeFormatter(ticketInfo.event.ends_at) }}
-                <v-spacer> </v-spacer>
+                <v-spacer></v-spacer>
+                <!--入場人数-->
                 <span class="text-h3"
                   ><v-icon>mdi-account-supervisor</v-icon
                   >{{ ticketInfo.ticket.person }}</span

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -42,6 +42,19 @@
             受付担当者は公演時間と入場人数を確認してください
           </p>
 
+          <!--この部分にUp-Nextを表示; v-if="isUpNext"で条件に合致するか調査-->
+          <v-card>
+            <v-card-title>次はこちら</v-card-title>
+            <v-card
+              v-for="ticketInfo in tickets"
+              :key="ticketInfo.ticket.id"
+              class="ma-2 pa-2"
+            >
+              <p>{{ ticketInfo.event.eventname }}</p>
+            </v-card>
+          </v-card>
+
+          <!--これより下に表示されるv-cardは，v-if="!isUpNext"のみ-->
           <v-card
             v-for="ticketInfo in tickets"
             :key="ticketInfo.ticket.id"
@@ -168,6 +181,8 @@
       <v-snackbar v-model="error_alert" color="red" elevation="2">
         {{ error_message }}
       </v-snackbar>
+
+      <p>{{ isUpNexts }}</p>
     </v-container>
   </v-app>
 </template>
@@ -185,6 +200,7 @@ type TicketInfo = {
 type Data = {
   groups: Group[]
   events: Event[]
+  upNexts: []
   tickets: TicketInfo[]
   cancelDialog: boolean
   selectedTicket: TicketInfo | null
@@ -203,6 +219,7 @@ export default Vue.extend({
       groups: [],
       events: [],
       tickets: [],
+      upNexts: [],
       cancelDialog: false,
       selectedTicket: null,
       display_userid: false,
@@ -217,6 +234,12 @@ export default Vue.extend({
     title: '整理券',
   },
   computed: {
+    // upNextsにデータを入れる関数
+    isUpNexts: function () {
+      // ここに，upNextかどうか判定する関数
+      return Date.now()
+    },
+
     /* 
     ここに，
     （現在時刻-15分）＜ticketInfo.event.starts_at && ticketInfo.event.ends_at<（現在時刻）

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -85,9 +85,10 @@
                     ></v-img>
                     <div class="ma-2">
                       <v-list-item-subtitle
-                        >{{ ticketInfo.event.eventname }}・{{
+                        >{{ ticketInfo.event.eventname
+                        }}<!--・{{
                           DateFormatter(ticketInfo.event.starts_at)
-                        }}</v-list-item-subtitle
+                        }}--></v-list-item-subtitle
                       >
                       <v-list-item-title class="text-h7">
                         {{ ticketInfo.group.title }}

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -43,7 +43,7 @@
             受付担当者は公演時間と入場人数を確認してください
           </p>
           <div class="text-center">
-            <v-chip label class="ma-1"
+            <v-chip v-if="time" label class="ma-1"
               >{{ time }} <span class="text-h5">{{ second }} </span></v-chip
             >
           </div>
@@ -69,8 +69,10 @@
                     class="ma-2"
                   ></v-img>
                   <div class="ma-2">
-                    <v-list-item-subtitle>
-                      {{ ticketInfo.event.eventname }}</v-list-item-subtitle
+                    <v-list-item-subtitle
+                      >{{ ticketInfo.event.eventname }}・{{
+                        DateFormatter(ticketInfo.event.starts_at)
+                      }}</v-list-item-subtitle
                     >
                     <v-list-item-title class="text-h7">
                       {{ ticketInfo.group.title }}
@@ -117,9 +119,9 @@
                       <v-icon>mdi-clock-time-nine</v-icon
                       ><span class="grey--text text--darken-2">公演 </span>
                       <span class="text-h5">{{
-                        DateFormatter(ticketInfo.event.starts_at)
+                        TimeFormatter(ticketInfo.event.starts_at)
                       }}</span>
-                      -{{ DateFormatter(ticketInfo.event.ends_at) }}
+                      -{{ TimeFormatter(ticketInfo.event.ends_at) }}
                     </p>
                     <v-spacer></v-spacer>
                     <p class="text-body-2">
@@ -251,11 +253,11 @@ export default Vue.extend({
         this.qrcodeUrl = await getQRCodeDataUrl(this.$auth.user?.sub as string)
       }
     } catch {}
-    // 100msごとに現在時刻を取得
-    setInterval(this.getNow, 100)
+    // 500msごとに現在時刻を取得
+    setInterval(this.getNow, 500)
 
-    // 10sごとに，開場中かどうかを判定
-    setInterval(this.isUpNext, 1000 * 10)
+    // 10sごとに，開場中かどうかを判定するつもりだったが，エラーが出るので止め
+    // setInterval(this.isUpNext, 10000)
   },
 
   methods: {
@@ -326,7 +328,7 @@ export default Vue.extend({
       })
       this.tickets = ticketInfos
     },
-    DateFormatter(inputDate: string) {
+    TimeFormatter(inputDate: string) {
       const d = new Date(inputDate)
       return (
         /*
@@ -340,6 +342,10 @@ export default Vue.extend({
         ':' +
         d.getMinutes().toString().padStart(2, '0')
       )
+    },
+    DateFormatter(inputDate: string) {
+      const d = new Date(inputDate)
+      return d.getMonth() + 1 + '/' + d.getDate()
     },
     selectCancelTicket(ticketInfo: TicketInfo) {
       this.cancelDialog = true

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -55,7 +55,14 @@
               受付担当者は公演時間と入場人数を確認してください
             </p>
             -->
-          <v-card v-if="tickets.length == 0" class="ma-1 pa-2">
+          <v-card
+            v-if="
+              tickets.length == 0 &&
+              ($auth.user?.jobTitle?.includes('Visited') ||
+                $auth.$state.strategy === 'ad')
+            "
+            class="ma-1 pa-2"
+          >
             <div>
               <v-card-title>まだ整理券を取得していません</v-card-title>
               <v-card-actions>

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -113,14 +113,6 @@
                           >{{ ticketInfo.ticket.person }}</span
                         >人
                       </v-list-item-subtitle>
-
-                      <v-chip
-                        v-if="isUsed(new Date(ticketInfo.event.ends_at))"
-                        color="error"
-                        outlined
-                        label
-                        ><v-icon>mdi-check</v-icon>公演終了</v-chip
-                      >
                       <v-chip
                         v-if="
                           isUpNext(
@@ -133,6 +125,16 @@
                         label
                         ><v-icon>mdi-theater</v-icon>開場中</v-chip
                       >
+                      <v-chip
+                        v-else-if="isUsed(new Date(ticketInfo.event.ends_at))"
+                        color="error"
+                        outlined
+                        label
+                        ><v-icon>mdi-check</v-icon>公演終了</v-chip
+                      >
+                      <v-chip v-else color="green" outlined label>
+                        <v-icon>mdi-account-clock</v-icon>開場前
+                      </v-chip>
                     </div>
                   </v-list-item>
                 </v-expansion-panel-header>

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -165,7 +165,11 @@
           </v-card>
 
           <!--キャンセルの有無を問うダイアログ-->
-          <v-dialog v-if="selectedTicket" v-model="cancelDialog">
+          <v-dialog
+            v-if="selectedTicket"
+            v-model="cancelDialog"
+            max-width="500"
+          >
             <v-card>
               <v-card-title class="text-h5">
                 本当にキャンセルしますか？

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -200,7 +200,7 @@ type TicketInfo = {
 type Data = {
   groups: Group[]
   events: Event[]
-  upNexts: []
+
   tickets: TicketInfo[]
   cancelDialog: boolean
   selectedTicket: TicketInfo | null
@@ -219,7 +219,7 @@ export default Vue.extend({
       groups: [],
       events: [],
       tickets: [],
-      upNexts: [],
+
       cancelDialog: false,
       selectedTicket: null,
       display_userid: false,

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -27,7 +27,7 @@
               <a
                 class="text-subtitle-2"
                 @click="display_userid = !display_userid"
-                >ユーザーIDを表示：</a
+                >ユーザーIDを表示: </a
               ><span v-show="display_userid"
                 >{{ $auth.user?.oid ?? $auth.user?.sub }}
                 <!--ADの場合ユーザーオブジェクトIDはoidに入ってる--></span
@@ -42,19 +42,6 @@
             受付担当者は公演時間と入場人数を確認してください
           </p>
 
-          <!--この部分にUp-Nextを表示; v-if="isUpNext"で条件に合致するか調査
-          <v-card>
-            <v-card-title>次はこちら</v-card-title>
-            <v-card
-              v-for="ticketInfo in tickets"
-              :key="ticketInfo.ticket.id"
-              class="ma-2 pa-2"
-            >
-              <p>{{ ticketInfo.event.eventname }}</p>
-            </v-card>
-          </v-card>
--->
-          <!--これより下に表示されるv-cardは，v-if="!isUpNext"のみ-->
           <v-card
             v-for="ticketInfo in tickets"
             :key="ticketInfo.ticket.id"
@@ -64,6 +51,8 @@
             rounded
             elevation="2"
           >
+            <!--公演の開始15分前-公演終了までの場合み表示されるdiv-->
+
             <v-list-item two-line>
               <v-list-item-content>
                 <div class="d-flex flex-no-wrap">
@@ -78,6 +67,18 @@
                       【{{ ticketInfo.event.eventname }}】{{
                         ticketInfo.group.title
                       }}
+                      <v-chip
+                        v-if="
+                          isUpNext(
+                            new Date(ticketInfo.event.starts_at),
+                            new Date(ticketInfo.event.ends_at)
+                          )
+                        "
+                        color="primary"
+                        outlined
+                        class="mx-2"
+                        ><v-icon>mdi-theater</v-icon>開場中</v-chip
+                      >
                     </v-list-item-title>
                     <v-list-item-subtitle>
                       {{ ticketInfo.group.groupname }}</v-list-item-subtitle
@@ -106,7 +107,7 @@
                   <div class="d-flex flex-no-wrap">
                     <p class="text-body-2">
                       <v-icon>mdi-clock-time-nine</v-icon
-                      ><span class="grey--text text--darken-2">公演:</span>
+                      ><span class="grey--text text--darken-2">公演 </span>
                       <span class="text-h5">{{
                         DateFormatter(ticketInfo.event.starts_at)
                       }}</span>
@@ -115,7 +116,7 @@
                     <v-spacer></v-spacer>
                     <p class="text-body-2">
                       <v-icon>mdi-account-supervisor</v-icon
-                      ><span class="grey--text text--darken-2">人数:</span
+                      ><span class="grey--text text--darken-2">人数 </span
                       ><span class="text-h5">{{
                         ticketInfo.ticket.person
                       }}</span>
@@ -181,8 +182,6 @@
       <v-snackbar v-model="error_alert" color="red" elevation="2">
         {{ error_message }}
       </v-snackbar>
-
-      <p>{{ isUpNexts }}</p>
     </v-container>
   </v-app>
 </template>
@@ -233,19 +232,6 @@ export default Vue.extend({
   head: {
     title: '整理券',
   },
-  computed: {
-    // upNextsにデータを入れる関数
-    isUpNexts: function () {
-      // ここに，upNextかどうか判定する関数
-      return Date.now()
-    },
-
-    /* 
-    ここに，
-    （現在時刻-15分）＜ticketInfo.event.starts_at && ticketInfo.event.ends_at<（現在時刻）
-    となるようなeventをupnNext= []の中に入れる処理を書く
-    */
-  },
   async created() {
     this.fetchTicket()
     try {
@@ -257,6 +243,27 @@ export default Vue.extend({
     } catch {}
   },
   methods: {
+    // upNextかどうかを判定する関数関数
+    isUpNext: function (start: Date, end: Date) {
+      // ここに，upNextかどうか判定する関数
+      // ここにupNextかどうか判定する関数
+      const date = new Date()
+      const currentTime: Date = new Date(date.getTime())
+      // 開演20分前の時刻を計算する
+      const MinutesBeforeStart = new Date(start.getTime() - 1000 * 60 * 20)
+
+      if (MinutesBeforeStart < currentTime && currentTime < end) {
+        return true
+      } else {
+        return false
+      }
+
+      /* 
+    ここに，
+    （現在時刻-15分）＜ticketInfo.event.starts_at && ticketInfo.event.ends_at<（現在時刻）
+    となるようなeventをupnNext= []の中に入れる処理を書く
+    */
+    },
     async fetchTicket() {
       const tickets: Ticket[] = await this.$axios.$get('/users/me/tickets')
 

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -38,9 +38,12 @@
           </v-card>
 
           <!--現在の時刻を表示-->
-          <div class="text-center">
+          <div class="text-center pa-1">
             <v-chip v-if="time" label class="ma-1"
               >{{ time }} <span class="text-h5">{{ second }} </span></v-chip
+            >
+            <v-btn class="mx-1 my-1" color="primary" @click="fetchTicket()"
+              ><v-icon>mdi-reload</v-icon>再読み込み</v-btn
             >
           </div>
 
@@ -182,10 +185,6 @@
               </v-card-actions>
             </v-card>
           </v-dialog>
-
-          <v-btn class="mx-1 my-3" color="primary" @click="fetchTicket()"
-            ><v-icon>mdi-reload</v-icon>再読み込み</v-btn
-          >
         </v-col>
       </v-row>
       <v-snackbar v-model="success_alert" color="success" elevation="2">

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -70,73 +70,69 @@
                 focusable
               >
                 <v-expansion-panel-header>
-                  <v-list-item two-line>
-                    <div class="d-flex flex-no-wrap">
-                      <v-img
+                  <v-list-item>
+                    <v-img
+                      v-if="ticketInfo.group.public_thumbnail_image_url != null"
+                      :src="ticketInfo.group.public_thumbnail_image_url"
+                      max-width="100px"
+                      height="165px"
+                      class="mr-2"
+                    ></v-img>
+                    <div class="ma-2">
+                      <v-list-item-subtitle
+                        >{{ ticketInfo.event.eventname }}・{{
+                          DateFormatter(ticketInfo.event.starts_at)
+                        }}</v-list-item-subtitle
+                      >
+                      <v-list-item-title class="text-h7">
+                        {{ ticketInfo.group.title }}
+                      </v-list-item-title>
+                      <v-list-item-subtitle>
+                        {{ ticketInfo.group.groupname }}</v-list-item-subtitle
+                      >
+                      <v-list-item-subtitle
+                        class="mt-2 grey--text text--darken-2"
+                      >
+                        <span class="text-h5"
+                          ><v-icon>mdi-clock-time-nine</v-icon
+                          >{{ TimeFormatter(ticketInfo.event.starts_at) }}</span
+                        >
+                        -{{ TimeFormatter(ticketInfo.event.ends_at) }}
+                      </v-list-item-subtitle>
+                      <v-list-item-subtitle
+                        class="mb-2 grey--text text--darken-2"
+                      >
+                        <span class="text-h5"
+                          ><v-icon>mdi-account-supervisor</v-icon
+                          >{{ ticketInfo.ticket.person }}</span
+                        >人
+                      </v-list-item-subtitle>
+
+                      <v-chip
+                        v-if="isUsed(new Date(ticketInfo.event.ends_at))"
+                        color="error"
+                        outlined
+                        label
+                        ><v-icon>mdi-check</v-icon>公演終了</v-chip
+                      >
+                      <v-chip
                         v-if="
-                          ticketInfo.group.public_thumbnail_image_url != null
+                          isUpNext(
+                            new Date(ticketInfo.event.starts_at),
+                            new Date(ticketInfo.event.ends_at)
+                          )
                         "
-                        :src="ticketInfo.group.public_thumbnail_image_url"
-                        max-width="60px"
-                        height="100px"
-                        class="ma-2"
-                      ></v-img>
-                      <div class="ma-2">
-                        <v-list-item-subtitle
-                          >{{ ticketInfo.event.eventname }}・{{
-                            DateFormatter(ticketInfo.event.starts_at)
-                          }}</v-list-item-subtitle
-                        >
-                        <v-list-item-title class="text-h7">
-                          {{ ticketInfo.group.title }}
-                        </v-list-item-title>
-                        <v-list-item-subtitle class="mb-4">
-                          {{ ticketInfo.group.groupname }}</v-list-item-subtitle
-                        >
-                        <v-chip
-                          v-if="isUsed(new Date(ticketInfo.event.ends_at))"
-                          color="error"
-                          outlined
-                          label
-                          ><v-icon>mdi-check</v-icon>公演終了</v-chip
-                        >
-                        <v-chip
-                          v-if="
-                            isUpNext(
-                              new Date(ticketInfo.event.starts_at),
-                              new Date(ticketInfo.event.ends_at)
-                            )
-                          "
-                          color="primary"
-                          outlined
-                          label
-                          ><v-icon>mdi-theater</v-icon>開場中</v-chip
-                        >
-                      </div>
+                        color="primary"
+                        outlined
+                        label
+                        ><v-icon>mdi-theater</v-icon>開場中</v-chip
+                      >
                     </div>
                   </v-list-item>
                 </v-expansion-panel-header>
                 <v-expansion-panel-content>
                   <v-divider></v-divider>
                   <v-card-text>
-                    <div class="d-flex flex-no-wrap">
-                      <p class="text-body-2">
-                        <v-icon>mdi-clock-time-nine</v-icon
-                        ><span class="grey--text text--darken-2">公演 </span>
-                        <span class="text-h5">{{
-                          TimeFormatter(ticketInfo.event.starts_at)
-                        }}</span>
-                        -{{ TimeFormatter(ticketInfo.event.ends_at) }}
-                      </p>
-                      <v-spacer></v-spacer>
-                      <p class="text-body-2">
-                        <v-icon>mdi-account-supervisor</v-icon
-                        ><span class="grey--text text--darken-2">人数 </span
-                        ><span class="text-h5">{{
-                          ticketInfo.ticket.person
-                        }}</span>
-                      </p>
-                    </div>
                     <p class="text-body-2 grey--text mb-0">
                       ID: {{ ticketInfo.ticket.id }}
                     </p>

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -27,9 +27,7 @@
             />
             <!--mx-autoで画像を中央寄せに-->
             <v-card-text
-              >ユーザーIDを表示:{{
-                $auth.user?.oid ?? $auth.user?.sub
-              }}</v-card-text
+              >User ID:{{ $auth.user?.oid ?? $auth.user?.sub }}</v-card-text
             >
 
             <!--

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -108,7 +108,7 @@
               </v-card-actions>
             </v-list-item>
             <v-expand-transition>
-              <div v-show="ticketInfo.detailShow">
+              <div v-show="ticketInfo.detailShow" class="ma-2">
                 <v-divider></v-divider>
 
                 <v-card-text>
@@ -253,6 +253,9 @@ export default Vue.extend({
     } catch {}
     // 100msごとに現在時刻を取得
     setInterval(this.getNow, 100)
+
+    // 10sごとに，開場中かどうかを判定
+    setInterval(this.isUpNext, 1000 * 10)
   },
 
   methods: {

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -2,7 +2,7 @@
   <v-app>
     <v-container name="ticket_container" class="ma-0 pa-0">
       <v-row class="ma-0 pa-0" justify="center" align-content="center">
-        <v-col class="ma-0 pa-0" col="6" md="6" sm="12">
+        <v-col col="6" md="6" sm="12">
           <v-card
             v-if="
               !(
@@ -41,94 +41,102 @@
           <p class="mx-1 my-0 py-0 text-caption grey--text">
             受付担当者は公演時間と入場人数を確認してください
           </p>
-          <div
+
+          <v-card
             v-for="ticketInfo in tickets"
             :key="ticketInfo.ticket.id"
-            class="my-2"
+            max-width="100%"
+            outlined
+            rounded
+            elevation="2"
           >
-            <v-card
-              class="mx-auto"
-              max-width="100%"
-              outlined
-              rounded
-              elevation="2"
-            >
-              <v-list-item two-line>
-                <v-list-item-content>
-                  <v-list-item-title class="text-h7 mb-1"
-                    >{{ ticketInfo.group.title }} -
-                    {{ ticketInfo.group.groupname }}</v-list-item-title
-                  >
-                  <v-list-item-subtitle>{{
-                    ticketInfo.event.eventname
-                  }}</v-list-item-subtitle>
-                </v-list-item-content>
+            <v-list-item two-line>
+              <v-list-item-content>
+                <!--
+                <v-img
+                  v-if="ticketInfo.group.public_thumbnail_image_url != null"
+                  :src="ticketInfo.group.public_thumbnail_image_url"
+                  max-width="20px"
+                ></v-img>
+              -->
+                <v-list-item-title class="text-h7 mb-1">
+                  【{{ ticketInfo.event.eventname }}】{{
+                    ticketInfo.group.title
+                  }}
+                </v-list-item-title>
+                <v-list-item-subtitle>
+                  {{ ticketInfo.group.groupname }}</v-list-item-subtitle
+                ></v-list-item-content
+              >
+              <v-card-actions>
+                <v-btn
+                  icon
+                  @click="ticketInfo.detailShow = !ticketInfo.detailShow"
+                >
+                  <v-icon>{{
+                    ticketInfo.detailShow
+                      ? 'mdi-chevron-up'
+                      : 'mdi-chevron-down'
+                  }}</v-icon>
+                </v-btn>
+              </v-card-actions>
+            </v-list-item>
+            <v-expand-transition>
+              <div v-show="ticketInfo.detailShow">
+                <v-divider></v-divider>
                 <v-card-actions>
                   <v-btn
-                    icon
-                    @click="ticketInfo.detailShow = !ticketInfo.detailShow"
-                  >
-                    <v-icon>{{
-                      ticketInfo.detailShow
-                        ? 'mdi-chevron-up'
-                        : 'mdi-chevron-down'
-                    }}</v-icon>
+                    class="text-body-2"
+                    :href="'/groups/' + ticketInfo.group.id"
+                    >詳細を見る
                   </v-btn>
                 </v-card-actions>
-              </v-list-item>
-              <v-expand-transition>
-                <div v-show="ticketInfo.detailShow" class="pa-1">
-                  <v-divider></v-divider>
-                  <v-card-text class="pa-1">
-                    <a
-                      class="text-body-2 mx-0 my-0 pa-0"
-                      :href="'/groups/' + ticketInfo.group.id"
-                      >{{ ticketInfo.group.groupname }}の団体紹介ページ</a
-                    >
-                    <p class="text-body-2 mx-0 my-0 pa-0">
-                      <v-icon>mdi-clock-time-nine</v-icon
-                      ><span class="grey--text text--darken-2">開幕時刻：</span
-                      >{{ DateFormatter(ticketInfo.event.starts_at) }} ~
-                      {{ DateFormatter(ticketInfo.event.ends_at) }}
-                    </p>
-                    <p class="text-body-2 mx-0 my-0 pa-0">
-                      <v-icon>mdi-account-supervisor</v-icon
-                      ><span class="grey--text text--darken-2"
-                        >同時入場人数：</span
-                      >{{ ticketInfo.ticket.person }}
-                    </p>
-                    <p class="text-body-2 mx-0 my-0 pa-0">
-                      <span class="grey--text text--darken-2">ID：</span
-                      >{{ ticketInfo.ticket.id }}
-                    </p>
-                    <v-btn @click="selectCancelTicket(ticketInfo)">
-                      <v-icon>mdi-close</v-icon>
-                      <p class="pa-0 ma-0">このチケットをキャンセル</p>
-                    </v-btn>
-                  </v-card-text>
-                </div>
-              </v-expand-transition>
-            </v-card>
-          </div>
-          <v-dialog
-            v-if="selectedTicket"
-            v-model="cancelDialog"
-            max-width="300"
-          >
+                <v-card-text>
+                  <p class="text-body-2">
+                    <v-icon>mdi-clock-time-nine</v-icon
+                    ><span class="grey--text text--darken-2">公演:</span
+                    >{{ DateFormatter(ticketInfo.event.starts_at) }} -
+                    {{ DateFormatter(ticketInfo.event.ends_at) }}
+                  </p>
+                  <p class="text-body-2">
+                    <v-icon>mdi-account-supervisor</v-icon
+                    ><span class="grey--text text--darken-2">人数:</span
+                    >{{ ticketInfo.ticket.person }}
+                  </p>
+                </v-card-text>
+                <v-card-actions
+                  ><v-btn color="error" @click="selectCancelTicket(ticketInfo)">
+                    <v-icon>mdi-close</v-icon>
+                    キャンセル
+                  </v-btn></v-card-actions
+                >
+                <v-card-text>
+                  <p class="text-body-2 grey--text">
+                    ID: {{ ticketInfo.ticket.id }}
+                  </p>
+                </v-card-text>
+              </div>
+            </v-expand-transition>
+          </v-card>
+
+          <v-dialog v-if="selectedTicket" v-model="cancelDialog">
             <v-card>
-              <v-card-title class="text-h5"
-                >{{ selectedTicket.group.title }} -
-                {{
-                  selectedTicket.group.groupname
-                }}の整理券をキャンセルしてもよろしいですか？</v-card-title
-              >
-              <v-card-text>このアクションは取り消せません</v-card-text>
+              <v-card-title class="text-h5">
+                本当にキャンセルしますか？
+              </v-card-title>
+              <v-card-title>
+                {{ selectedTicket.group.title }}
+              </v-card-title>
+              <v-card-subtitle>{{
+                selectedTicket.group.groupname
+              }}</v-card-subtitle>
+              <v-card-text>この操作は取り消せません</v-card-text>
               <v-card-actions>
                 <v-spacer></v-spacer>
-                <v-btn text @click="cancelDialog = false">いいえ</v-btn>
-                <v-btn color="primary" @click="CancelTicket(selectedTicket)"
-                  >はい</v-btn
+                <v-btn color="primary" @click="cancelDialog = false"
+                  >いいえ</v-btn
                 >
+                <v-btn text @click="CancelTicket(selectedTicket)">はい</v-btn>
               </v-card-actions>
             </v-card>
           </v-dialog>
@@ -139,7 +147,7 @@
             >
           </div>
           <v-btn class="mx-1 my-3" color="primary" @click="fetchTicket()"
-            >再読み込み</v-btn
+            ><v-icon>mdi-reload</v-icon>再読み込み</v-btn
           >
         </v-col>
       </v-row>

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -10,20 +10,22 @@
                 $auth.$state.strategy === 'ad'
               )
             "
-            outlined
           >
-            <v-card-title class="ma-3 pa-0 red--text text-subtitle-1">
-              <v-icon color="red">mdi-alert-circle</v-icon>
-              未アクティベートなアカウント
-            </v-card-title>
-            <p class="caption mx-3 my-1 grey--text text--darken-1">
-              整理券を取得・使用するには校内への入場処理が必要です。以下のQRコードまたはユーザーIDを校門にいるチーフ会の生徒に提示してください
-            </p>
-            <p class="caption mx-3 my-1 grey--text text--darken-1">
-              ※本校生徒のアカウントは開場と同時にアクティベートされます
-            </p>
-            <img class="mx-1 my-0" style="display: block" :src="qrcodeUrl" />
-            <div class="mx-3 my-1">
+            <v-card-title>まずは日比谷高校に入場しよう！</v-card-title>
+            <v-card-text>
+              【保護者】校門にいる係生徒に以下のQRコードを提示してください。保護者のみなさんが整理券を取得・使用するには校内への入場が必要です。
+            </v-card-text>
+            <v-card-text>
+              【日比谷生】開場時間になると操作できるようになります。校門での入校処理は不要です。
+            </v-card-text>
+            <v-img
+              class="mx-auto my-0"
+              style="display: block"
+              :src="qrcodeUrl"
+              width="90%"
+            />
+            <!--mx-autoで画像を中央寄せに-->
+            <v-card-text class="mx-3 my-1">
               <a
                 class="text-subtitle-2"
                 @click="display_userid = !display_userid"
@@ -32,7 +34,7 @@
                 >{{ $auth.user?.oid ?? $auth.user?.sub }}
                 <!--ADの場合ユーザーオブジェクトIDはoidに入ってる--></span
               >
-            </div>
+            </v-card-text>
           </v-card>
 
           <!--現在の時刻を表示-->

--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -47,11 +47,13 @@
             -->
           </v-card>
 
-          <!--現在時刻を表示-->
-          <div class="text-center pa-1">
+          <!--現在時刻を表示・現在時刻を取得するとv-progress-linearが正常に動作しないため非表示-->
+          <!--
             <v-chip v-if="time" label class="ma-1"
               >{{ time }} <span class="text-h5">{{ seconds }} </span></v-chip
             >
+            -->
+          <div class="text-center pa-1">
             <v-btn class="mx-1 my-1" color="primary" @click="fetchTicket()"
               ><v-icon>mdi-reload</v-icon>再読み込み</v-btn
             >
@@ -86,6 +88,64 @@
             </div>
           </v-card>
 
+          <div
+            v-for="ticketInfo in tickets"
+            :key="ticketInfo.ticket.id"
+            focusable
+          >
+            <v-card
+              v-if="
+                isUpNext(
+                  new Date(ticketInfo.event.starts_at),
+                  new Date(ticketInfo.event.ends_at)
+                )
+              "
+              class="pa-3 ma-3"
+            >
+              <v-card-title class="mb-2"
+                ><v-icon>mdi-ticket</v-icon>整理券
+                <v-spacer></v-spacer>
+                <v-chip color="primary" outlined label
+                  ><v-icon>mdi-theater</v-icon>開場中</v-chip
+                ></v-card-title
+              >
+              <v-card-subtitle
+                >この画面を各クラスの受付に提示してください。</v-card-subtitle
+              >
+              <v-divider></v-divider>
+
+              <v-card-title class="text-h7">
+                {{ ticketInfo.group.title }}
+              </v-card-title>
+              <v-card-subtitle class="pb-0">
+                {{ ticketInfo.group.groupname }}</v-card-subtitle
+              >
+
+              <v-card-subtitle class="grey--text text--darken-2">
+                <span class="text-h3"
+                  ><v-icon>mdi-clock-time-nine</v-icon
+                  >{{ timeFormatter(ticketInfo.event.starts_at) }}</span
+                >
+                -{{ timeFormatter(ticketInfo.event.ends_at) }}
+                <v-spacer> </v-spacer>
+                <span class="text-h3"
+                  ><v-icon>mdi-account-supervisor</v-icon
+                  >{{ ticketInfo.ticket.person }}</span
+                >人
+              </v-card-subtitle>
+              <v-progress-linear
+                indeterminate
+                height="10px"
+                color="teal"
+              ></v-progress-linear>
+              <v-img
+                v-if="ticketInfo.group.public_thumbnail_image_url != null"
+                :src="ticketInfo.group.public_thumbnail_image_url"
+                max-width="100%"
+                height="130px"
+              ></v-img>
+            </v-card>
+          </div>
           <!--取得した整理券一覧-->
           <v-card flat class="ma-1">
             <v-expansion-panels>
@@ -94,7 +154,7 @@
                 :key="ticketInfo.ticket.id"
                 focusable
               >
-                <v-expansion-panel-header class="pa-1">
+                <v-expansion-panel-header class="pa-3">
                   <v-list-item>
                     <v-img
                       v-if="ticketInfo.group.public_thumbnail_image_url != null"
@@ -105,9 +165,10 @@
                     ></v-img>
                     <div class="ma-2">
                       <!--取得した整理券の情報を表示-->
-                      <v-list-item-subtitle>{{
-                        ticketInfo.event.eventname
-                      }}</v-list-item-subtitle>
+                      <v-list-item-subtitle
+                        >{{ dateFormatter(ticketInfo.event.starts_at) }}
+                        {{ ticketInfo.event.eventname }}</v-list-item-subtitle
+                      >
                       <v-list-item-title class="text-h7">
                         {{ ticketInfo.group.title }}
                       </v-list-item-title>
@@ -196,10 +257,12 @@
               <v-card-title class="text-h5">
                 本当にキャンセルしますか？
               </v-card-title>
-              <v-card-title>
-                【{{ selectedTicket.event.eventname }}】{{
-                  selectedTicket.group.title
-                }}
+              <v-card-subtitle class="pt-5 pb-0"
+                >{{ dateFormatter(selectedTicket.event.starts_at) }}
+                {{ selectedTicket.event.eventname }}</v-card-subtitle
+              >
+              <v-card-title class="pt-0">
+                {{ selectedTicket.group.title }}
               </v-card-title>
               <v-card-subtitle>{{
                 selectedTicket.group.groupname
@@ -285,11 +348,13 @@ export default Vue.extend({
       }
     } catch {}
     // 500msごとに現在時刻を取得
-    setInterval(this.getNow, 500)
+    // setInterval(this.getNow, 500)
   },
 
   methods: {
     // 現在時刻を取得
+    // 現在時刻を取得するとv-progress-linearが正常に動作しないため非表示
+    /*
     getNow: function () {
       const today = new Date()
       const date =
@@ -304,6 +369,7 @@ export default Vue.extend({
       this.time = dateTime
       this.seconds = seconds + ''
     },
+    */
 
     // upNext（開演X分前から終演時刻まで）かどうかを判定するmethod
     // 引数には（開演時刻，終演時刻）を代入


### PR DESCRIPTION
## What?
自分が取得した整理券の一覧画面のデザインを大幅に改訂．

## Why?
- 自分の整理券を確認しやすいようにするため．
- 各クラスの受付担当者が簡単に整理券を確認できるようにするため．

## How?
- 説明文章を平易に改訂．
- UIをシンプルなものに変更．
- 開場されているかどうかを「開場前」「開場中」「公演終了」の3種類に分けて表示．
- 開場中の整理券がある場合は最上部に大きく表示される

## Screenshots
### ※最新commitにて，v-imgにはcontain propが追加されています．
1. 開場中の整理券がある場合は最上部に大きく表示される
2. 「あなたの整理券」
3. 入場していない場合（もうちょっと可愛くしたい）
4. 整理券を取得していない場合
![ezgif-1-0ecd45d4d3](https://github.com/hibiya-itchief/quaint-app/assets/67095865/10f5d99e-1fc7-4187-a5db-5e581edc5c58)
![tickets](https://github.com/hibiya-itchief/quaint-app/assets/67095865/aadbd215-1519-422a-9367-ebd79d433b36)
<img width="378" alt="Screenshot 2023-07-31 at 21 47 42" src="https://github.com/hibiya-itchief/quaint-app/assets/67095865/45510985-457e-47ae-b542-17bf69357dd3">
<img width="375" alt="Screenshot 2023-07-31 at 21 49 41" src="https://github.com/hibiya-itchief/quaint-app/assets/67095865/fcec87f9-b3c5-4d42-b1bd-d32f7e541deb">
