### PR TITLE
一覧ページをスマホで見た時の表示件数を多くする

### DIFF
--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -55,12 +55,11 @@
         >
           <!-- <class="d-flex flex-column">で，「もっと見る」が常に最下部に -->
           <v-card
-            height="160px"
+            height="100%"
             class="d-flex flex-column my-1"
             :to="'/groups/' + group.id"
           >
             <div class="d-flex flex-no-wrap">
-              <!--v-img でv-imgを挟むのは気持ち悪いよね-->
               <v-avatar size="100" rounded="0">
                 <v-img
                   v-if="group.public_thumbnail_image_url != null"
@@ -70,8 +69,11 @@
               </v-avatar>
               <div>
                 <v-card-title class="my-1 py-1">
-                  {{ group.title }}/{{ group.groupname }}
+                  {{ group.title }}
                 </v-card-title>
+                <v-card-subtitle>
+                  {{ group.groupname }}
+                </v-card-subtitle>
                 <!-- v-cardのheightが一意に定まらないので，Descriptionを無効化．
                 <v-card-text class="my-1 py-1">
                   {{ group.description }}

--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -50,7 +50,7 @@
           :key="group.id"
           cols="12"
           sm="6"
-          md="6"
+          md="4"
           lg="4"
           class="my-0 py-2"
         >
@@ -75,6 +75,9 @@
                 <v-card-subtitle class="pb-0">
                   {{ group.groupname }}
                 </v-card-subtitle>
+                <v-card-text class="my-1 py-1 text-caption grey--text">
+                  {{ group.description?.substring(0, 50) + '...' }}
+                </v-card-text>
                 <v-card-actions class="pb-0">
                   <v-chip-group column>
                     <v-chip
@@ -87,11 +90,6 @@
                     </v-chip>
                   </v-chip-group>
                 </v-card-actions>
-                <!-- v-cardのheightが一意に定まらないので，Descriptionを無効化．
-                <v-card-text class="my-1 py-1">
-                  {{ group.description?.substring(0, 30) + '...' }}
-                </v-card-text>
-                -->
               </div>
             </div>
           </v-card>

--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -82,29 +82,28 @@
                 <v-img
                   v-if="group.public_thumbnail_image_url != null"
                   height="120px"
-                  width="160px"
-                  contain
+                  width="90px"
                   :src="group.public_thumbnail_image_url"
                 ></v-img>
                 <v-img
                   v-else
                   :class="HashColor(group.id)"
                   height="120px"
-                  width="160px"
+                  width="90px"
                 ></v-img>
                 <!--</v-avatar>-->
               </div>
               <div class="px-1">
-                <v-card-title class="pt-1">
+                <v-card-title class="pb-2">
                   {{ group.title }}
                 </v-card-title>
                 <v-card-subtitle class="pb-0">
                   {{ group.groupname }}
                 </v-card-subtitle>
-                <v-card-text class="my-1 py-1 text-caption grey--text">
-                  {{ group.description?.substring(0, 50) + '...' }}
+                <v-card-text class="my-0 py-0 text-caption grey--text">
+                  {{ group.description?.substring(0, 18) + '...' }}
                 </v-card-text>
-                <v-card-actions class="pb-0">
+                <v-card-actions class="py-0">
                   <v-chip-group column>
                     <v-chip
                       v-for="tag in group.tags"

--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -81,15 +81,16 @@
                 <!--<v-avatar v-if="$vuetify.breakpoint.xs" size="100" rounded="0">-->
                 <v-img
                   v-if="group.public_thumbnail_image_url != null"
-                  height="140px"
-                  width="100px"
+                  height="120px"
+                  width="160px"
+                  contain
                   :src="group.public_thumbnail_image_url"
                 ></v-img>
                 <v-img
                   v-else
                   :class="HashColor(group.id)"
-                  height="140px"
-                  width="100px"
+                  height="120px"
+                  width="160px"
                 ></v-img>
                 <!--</v-avatar>-->
               </div>

--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -49,14 +49,15 @@
           v-show="filterGroups(group)"
           :key="group.id"
           cols="12"
-          md="4"
           sm="6"
-          class="my-0"
+          md="6"
+          lg="4"
+          class="my-0 py-2"
         >
           <!-- <class="d-flex flex-column">で，「もっと見る」が常に最下部に -->
           <v-card
             height="100%"
-            class="d-flex flex-column my-1"
+            class="d-flex flex-column ma-0 pa-2"
             :to="'/groups/' + group.id"
           >
             <div class="d-flex flex-no-wrap">
@@ -67,25 +68,30 @@
                 ></v-img>
                 <v-img v-else :class="HashColor(group.id)"></v-img>
               </v-avatar>
-              <div>
-                <v-card-title class="my-1 py-1">
+              <div class="px-1">
+                <v-card-title class="pt-1">
                   {{ group.title }}
                 </v-card-title>
-                <v-card-subtitle>
+                <v-card-subtitle class="pb-0">
                   {{ group.groupname }}
                 </v-card-subtitle>
+                <v-card-actions class="pb-0">
+                  <v-chip-group column>
+                    <v-chip
+                      v-for="tag in group.tags"
+                      :key="tag.id"
+                      disabled
+                      small
+                    >
+                      {{ tag.tagname }}
+                    </v-chip>
+                  </v-chip-group>
+                </v-card-actions>
                 <!-- v-cardのheightが一意に定まらないので，Descriptionを無効化．
                 <v-card-text class="my-1 py-1">
                   {{ group.description }}
                 </v-card-text>
                 -->
-                <v-card-actions class="my-0 py-0">
-                  <v-chip-group column>
-                    <v-chip v-for="tag in group.tags" :key="tag.id" disabled>
-                      {{ tag.tagname }}
-                    </v-chip>
-                  </v-chip-group>
-                </v-card-actions>
               </div>
             </div>
           </v-card>

--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -61,21 +61,34 @@
             :to="'/groups/' + group.id"
           >
             <div class="d-flex flex-no-wrap">
-              <v-avatar size="100" rounded="0">
-                <v-img
-                  v-if="group.public_thumbnail_image_url != null"
-                  :src="group.public_thumbnail_image_url"
-                ></v-img>
-                <v-img v-else :class="HashColor(group.id)"></v-img>
-              </v-avatar>
+              <div>
+                <v-avatar size="105" rounded="0">
+                  <v-img
+                    v-if="group.public_thumbnail_image_url != null"
+                    :src="group.public_thumbnail_image_url"
+                  ></v-img>
+                  <v-img v-else :class="HashColor(group.id)"></v-img>
+                </v-avatar>
+                <v-card-actions class="px-0 ax-0">
+                  <!--お気に入りボタン：コード未実装-->
+                  <v-btn icon><v-icon>mdi-bookmark-outline</v-icon></v-btn>
+                  <!--配布ステータスボタン：コード未実装-->
+                  <v-chip icon color="gray" label
+                    ><v-icon small>mdi-cancel</v-icon>未発</v-chip
+                  >
+                </v-card-actions>
+              </div>
               <div class="px-1">
                 <v-card-title class="pt-1">
                   {{ group.title }}
                 </v-card-title>
-                <v-card-subtitle class="pb-0">
+                <v-card-subtitle>
                   {{ group.groupname }}
                 </v-card-subtitle>
-                <v-card-actions class="pb-0">
+                <v-card-text class="pb-0">
+                  {{ group.description?.substring(0, 30) + '...' }}
+                </v-card-text>
+                <v-card-actions>
                   <v-chip-group column>
                     <v-chip
                       v-for="tag in group.tags"
@@ -87,11 +100,6 @@
                     </v-chip>
                   </v-chip-group>
                 </v-card-actions>
-                <!-- v-cardのheightが一意に定まらないので，Descriptionを無効化．
-                <v-card-text class="my-1 py-1">
-                  {{ group.description?.substring(0, 30) + '...' }}
-                </v-card-text>
-                -->
               </div>
             </div>
           </v-card>

--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -78,18 +78,21 @@
             </div>
             <div class="d-flex flex-no-wrap">
               <div v-if="$vuetify.breakpoint.xs">
+                <!--<v-avatar v-if="$vuetify.breakpoint.xs" size="100" rounded="0">-->
                 <v-img
                   v-if="group.public_thumbnail_image_url != null"
                   height="120px"
-                  width="120px"
+                  width="160px"
+                  contain
                   :src="group.public_thumbnail_image_url"
                 ></v-img>
                 <v-img
                   v-else
                   :class="HashColor(group.id)"
                   height="120px"
-                  width="120px"
+                  width="160px"
                 ></v-img>
+                <!--</v-avatar>-->
               </div>
               <div class="px-1">
                 <v-card-title class="pt-1">
@@ -98,10 +101,7 @@
                 <v-card-subtitle class="pb-0">
                   {{ group.groupname }}
                 </v-card-subtitle>
-                <v-card-text
-                  v-if="!$vuetify.breakpoint.xs"
-                  class="my-1 py-1 text-caption grey--text"
-                >
+                <v-card-text class="my-1 py-1 text-caption grey--text">
                   {{ group.description?.substring(0, 50) + '...' }}
                 </v-card-text>
                 <v-card-actions class="pb-0">

--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -61,34 +61,21 @@
             :to="'/groups/' + group.id"
           >
             <div class="d-flex flex-no-wrap">
-              <div>
-                <v-avatar size="105" rounded="0">
-                  <v-img
-                    v-if="group.public_thumbnail_image_url != null"
-                    :src="group.public_thumbnail_image_url"
-                  ></v-img>
-                  <v-img v-else :class="HashColor(group.id)"></v-img>
-                </v-avatar>
-                <v-card-actions class="px-0 ax-0">
-                  <!--お気に入りボタン：コード未実装-->
-                  <v-btn icon><v-icon>mdi-bookmark-outline</v-icon></v-btn>
-                  <!--配布ステータスボタン：コード未実装-->
-                  <v-chip icon color="gray" label
-                    ><v-icon small>mdi-cancel</v-icon>未発</v-chip
-                  >
-                </v-card-actions>
-              </div>
+              <v-avatar size="100" rounded="0">
+                <v-img
+                  v-if="group.public_thumbnail_image_url != null"
+                  :src="group.public_thumbnail_image_url"
+                ></v-img>
+                <v-img v-else :class="HashColor(group.id)"></v-img>
+              </v-avatar>
               <div class="px-1">
                 <v-card-title class="pt-1">
                   {{ group.title }}
                 </v-card-title>
-                <v-card-subtitle>
+                <v-card-subtitle class="pb-0">
                   {{ group.groupname }}
                 </v-card-subtitle>
-                <v-card-text class="pb-0">
-                  {{ group.description?.substring(0, 30) + '...' }}
-                </v-card-text>
-                <v-card-actions>
+                <v-card-actions class="pb-0">
                   <v-chip-group column>
                     <v-chip
                       v-for="tag in group.tags"
@@ -100,6 +87,11 @@
                     </v-chip>
                   </v-chip-group>
                 </v-card-actions>
+                <!-- v-cardのheightが一意に定まらないので，Descriptionを無効化．
+                <v-card-text class="my-1 py-1">
+                  {{ group.description?.substring(0, 30) + '...' }}
+                </v-card-text>
+                -->
               </div>
             </div>
           </v-card>

--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -55,27 +55,37 @@
         >
           <!-- <class="d-flex flex-column">で，「もっと見る」が常に最下部に -->
           <v-card
-            height="100%"
+            height="160px"
             class="d-flex flex-column my-1"
             :to="'/groups/' + group.id"
           >
-            <v-img
-              v-if="group.public_thumbnail_image_url != null"
-              max-height="180px"
-              :src="group.public_thumbnail_image_url"
-            ></v-img>
-            <v-img v-else :class="HashColor(group.id)" height="180px"></v-img>
-            <v-card-title class="my-1 py-1"
-              >{{ group.title }}/{{ group.groupname }}</v-card-title
-            >
-            <v-card-text class="my-1 py-1">{{ group.description }}</v-card-text>
-            <v-card-actions class="my-0 py-0">
-              <v-chip-group column>
-                <v-chip v-for="tag in group.tags" :key="tag.id" disabled>{{
-                  tag.tagname
-                }}</v-chip>
-              </v-chip-group>
-            </v-card-actions>
+            <div class="d-flex flex-no-wrap">
+              <!--v-img でv-imgを挟むのは気持ち悪いよね-->
+              <v-avatar size="100" rounded="0">
+                <v-img
+                  v-if="group.public_thumbnail_image_url != null"
+                  :src="group.public_thumbnail_image_url"
+                ></v-img>
+                <v-img v-else :class="HashColor(group.id)"></v-img>
+              </v-avatar>
+              <div>
+                <v-card-title class="my-1 py-1">
+                  {{ group.title }}/{{ group.groupname }}
+                </v-card-title>
+                <!-- v-cardのheightが一意に定まらないので，Descriptionを無効化．
+                <v-card-text class="my-1 py-1">
+                  {{ group.description }}
+                </v-card-text>
+                -->
+                <v-card-actions class="my-0 py-0">
+                  <v-chip-group column>
+                    <v-chip v-for="tag in group.tags" :key="tag.id" disabled>
+                      {{ tag.tagname }}
+                    </v-chip>
+                  </v-chip-group>
+                </v-card-actions>
+              </div>
+            </div>
           </v-card>
         </v-col>
       </v-row>

--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -89,7 +89,7 @@
                 </v-card-actions>
                 <!-- v-cardのheightが一意に定まらないので，Descriptionを無効化．
                 <v-card-text class="my-1 py-1">
-                  {{ group.description }}
+                  {{ group.description?.substring(0, 30) + '...' }}
                 </v-card-text>
                 -->
               </div>

--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -81,16 +81,15 @@
                 <!--<v-avatar v-if="$vuetify.breakpoint.xs" size="100" rounded="0">-->
                 <v-img
                   v-if="group.public_thumbnail_image_url != null"
-                  height="120px"
-                  width="160px"
-                  contain
+                  height="140px"
+                  width="100px"
                   :src="group.public_thumbnail_image_url"
                 ></v-img>
                 <v-img
                   v-else
                   :class="HashColor(group.id)"
-                  height="120px"
-                  width="160px"
+                  height="140px"
+                  width="100px"
                 ></v-img>
                 <!--</v-avatar>-->
               </div>

--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -78,21 +78,18 @@
             </div>
             <div class="d-flex flex-no-wrap">
               <div v-if="$vuetify.breakpoint.xs">
-                <!--<v-avatar v-if="$vuetify.breakpoint.xs" size="100" rounded="0">-->
                 <v-img
                   v-if="group.public_thumbnail_image_url != null"
                   height="120px"
-                  width="160px"
-                  contain
+                  width="120px"
                   :src="group.public_thumbnail_image_url"
                 ></v-img>
                 <v-img
                   v-else
                   :class="HashColor(group.id)"
                   height="120px"
-                  width="160px"
+                  width="120px"
                 ></v-img>
-                <!--</v-avatar>-->
               </div>
               <div class="px-1">
                 <v-card-title class="pt-1">
@@ -101,7 +98,10 @@
                 <v-card-subtitle class="pb-0">
                   {{ group.groupname }}
                 </v-card-subtitle>
-                <v-card-text class="my-1 py-1 text-caption grey--text">
+                <v-card-text
+                  v-if="!$vuetify.breakpoint.xs"
+                  class="my-1 py-1 text-caption grey--text"
+                >
                   {{ group.description?.substring(0, 50) + '...' }}
                 </v-card-text>
                 <v-card-actions class="pb-0">

--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -60,14 +60,40 @@
             class="d-flex flex-column ma-0 pa-2"
             :to="'/groups/' + group.id"
           >
+            <div v-if="!$vuetify.breakpoint.xs">
+              <v-img
+                v-if="group.public_thumbnail_image_url != null"
+                height="180px"
+                aspect-ratio="4/3"
+                contain
+                :src="group.public_thumbnail_image_url"
+              ></v-img>
+              <v-img
+                v-else
+                :class="HashColor(group.id)"
+                height="180px"
+                aspect-ratio="4/3"
+                contain
+              ></v-img>
+            </div>
             <div class="d-flex flex-no-wrap">
-              <v-avatar size="100" rounded="0">
+              <div v-if="$vuetify.breakpoint.xs">
+                <!--<v-avatar v-if="$vuetify.breakpoint.xs" size="100" rounded="0">-->
                 <v-img
                   v-if="group.public_thumbnail_image_url != null"
+                  height="120px"
+                  width="160px"
+                  contain
                   :src="group.public_thumbnail_image_url"
                 ></v-img>
-                <v-img v-else :class="HashColor(group.id)"></v-img>
-              </v-avatar>
+                <v-img
+                  v-else
+                  :class="HashColor(group.id)"
+                  height="120px"
+                  width="160px"
+                ></v-img>
+                <!--</v-avatar>-->
+              </div>
               <div class="px-1">
                 <v-card-title class="pt-1">
                   {{ group.title }}


### PR DESCRIPTION
## What?
- /groups/について，スマホで見た時に表示される団体の数を多くする

## Why?
- /groups/内でより速く目的の団体が見つかるようにするため．

## How?
- 画面サイズxsの場合はサムネイルを縦長（縦180px:横240px）にし，それ以外の団体情報を右に表示
- 画面サイズsm以上の場合はサムネイルを横長（縦180px:横90px）

## Screenshots
1. iPhone12mini（xs）
2. iPad Pro（md辺りか）
<img width="375" alt="image" src="https://github.com/hibiya-itchief/quaint-app/assets/67095865/63529ff2-0b58-4fb4-99ce-59ca40a318a5">
<img width="1024" alt="image" src="https://github.com/hibiya-itchief/quaint-app/assets/67095865/84f41e6c-e36e-4586-af58-af5e5e081a47">
