### PR TITLE
fix: /groupsのタイトル・説明文を1行に収める 

### DIFF
--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -126,14 +126,6 @@
     </v-container>
   </v-app>
 </template>
-<style>
-.text-truncate {
-  display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-</style>
 <script lang="ts">
 import { Group, Tag } from 'types/quaint'
 import Vue from 'vue'
@@ -265,3 +257,11 @@ export default Vue.extend({
   },
 })
 </script>
+<style>
+.text-truncate {
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+</style>

--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -94,15 +94,17 @@
                 ></v-img>
                 <!--</v-avatar>-->
               </div>
-              <div class="px-1">
-                <v-card-title class="pb-2">
+              <div class="px-1 text-truncate">
+                <v-card-title class="pb-2 text-truncate">
                   {{ group.title }}
                 </v-card-title>
-                <v-card-subtitle class="pb-0">
+                <v-card-subtitle class="pb-0 text-truncate">
                   {{ group.groupname }}
                 </v-card-subtitle>
-                <v-card-text class="my-0 py-0 text-caption grey--text">
-                  {{ group.description?.substring(0, 18) + '...' }}
+                <v-card-text
+                  class="my-0 py-0 text-caption grey--text text-truncate"
+                >
+                  {{ group.description }}
                 </v-card-text>
                 <v-card-actions class="py-0">
                   <v-chip-group column>
@@ -124,7 +126,14 @@
     </v-container>
   </v-app>
 </template>
-
+<style>
+.text-truncate {
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+</style>
 <script lang="ts">
 import { Group, Tag } from 'types/quaint'
 import Vue from 'vue'

--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -51,7 +51,7 @@
           cols="12"
           sm="6"
           md="4"
-          lg="4"
+          lg="3"
           class="my-0 py-2"
         >
           <!-- <class="d-flex flex-column">で，「もっと見る」が常に最下部に -->


### PR DESCRIPTION
- タイトル，団体名，説明文が，横幅に寄らず一行に収まるように変更．
- [えいすけの指摘](https://github.com/hibiya-itchief/quaint-app/pull/249#discussion_r1284456347)を元にlg="3"に変更
<img width="966" alt="image" src="https://github.com/hibiya-itchief/quaint-app/assets/67095865/30137cd4-e756-4020-b8ca-62894b3d0f08">

<img width="468" alt="image" src="https://github.com/hibiya-itchief/quaint-app/assets/67095865/d5fa5e0e-5332-435d-b421-0aea38cd0548">
