### PR TITLE
/groupsのソート機能

### DIFF
--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -182,11 +182,26 @@ export default Vue.extend({
     }
   },
   created() {
-    // 毎回同じ順番で表示されないようにgroupsの配列をランダムな順番にする
-    // 各groupが有しているtagをAPIから取得し，groups配列の中のオブジェクトに"tags"というキーを設けてgroupsとtagsの情報を結びつけている。
+    this.SortGroups('id', false)
   },
 
   methods: {
+    SortGroups(sort: 'id' | 'groupname' | 'title', reverse: boolean) {
+      for (let i = 0; i < this.groups.length; i++) {
+        if (this.groups[i].title === null) {
+          this.groups[i].title = ''
+        }
+      }
+      this.groups.sort((x, y) => {
+        if (x[sort] > y[sort]) return 1
+        if (x[sort] < y[sort]) return -1
+        return 0
+      })
+      if (reverse === true) {
+        this.groups.reverse()
+      }
+    },
+
     SearchGroups(input: string) {
       if (input === '') {
         this.searchB = false

--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -9,6 +9,36 @@
             prepend-inner-icon="mdi-magnify"
             @input="SearchGroups($event)"
           ></v-text-field>
+          <v-menu offset-y>
+            <template #activator="{ on, attrs }">
+              <v-btn
+                outlined
+                color="black"
+                class="justify-end"
+                v-bind="attrs"
+                v-on="on"
+                ><v-icon>mdi-sort</v-icon></v-btn
+              >
+            </template>
+            <v-list>
+              <v-list-item @click="SortGroups('id', false)">
+                <v-list-item-title>団体ID(昇順)</v-list-item-title></v-list-item
+              ><v-list-item @click="SortGroups('id', true)">
+                <v-list-item-title
+                  >団体ID(降順)</v-list-item-title
+                > </v-list-item
+              ><v-list-item @click="SortGroups('groupname', false)">
+                <v-list-item-title>団体名(昇順)</v-list-item-title></v-list-item
+              ><v-list-item @click="SortGroups('groupname', true)">
+                <v-list-item-title>団体名(降順)</v-list-item-title></v-list-item
+              ><v-list-item @click="SortGroups('title', false)">
+                <v-list-item-title>演目名(昇順)</v-list-item-title></v-list-item
+              ><v-list-item @click="SortGroups('title', true)">
+                <v-list-item-title>演目名(降順)</v-list-item-title>
+              </v-list-item>
+            </v-list>
+          </v-menu>
+
           <p v-show="searchB" class="ma-0 pa-0 text-caption">
             "{{ search_query }}"の検索結果({{ search_result_number }}件)
           </p>
@@ -182,7 +212,7 @@ export default Vue.extend({
     }
   },
   created() {
-    this.SortGroups('id', false)
+    this.SortGroups('groupname', false)
   },
 
   methods: {


### PR DESCRIPTION
* #234 


**現在の仮実装で起きている問題一覧**

* ソートするボタンの位置やデザインが不十分
* ソートするボタンを押して出るメニューに、現在のソート順を表示したい
* groups.titleが`null`であっても`string`に直すための機構を作ったのに、「nullかもしれない」と杞憂するエラーが出ている
