### PR TITLE
adminページのリンクをログアウトボタンの左に

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -69,6 +69,14 @@
               </p>
             </v-card-text>
             <v-card-actions>
+              <v-btn
+                v-show="$auth.user?.groups?.includes(userGroups.admin)"
+                outlined
+                color="primary"
+                to="/admin"
+              >
+                管理者用画面
+              </v-btn>
               <v-spacer></v-spacer>
               <v-btn outlined color="primary" @click="logout()">
                 ログアウト
@@ -151,14 +159,6 @@
       <v-btn to="/tickets">
         <span>整理券</span>
         <v-icon>mdi-ticket</v-icon>
-      </v-btn>
-
-      <v-btn
-        v-show="$auth.user?.groups?.includes(userGroups.admin)"
-        to="/admin"
-      >
-        <span>👑Admin</span>
-        <v-icon>mdi-crown</v-icon>
       </v-btn>
     </v-bottom-navigation>
   </v-app>


### PR DESCRIPTION
表題の通り

表題のボタンを押すと青い状態が残り続けるが、
adminページを開いている状態を意味しているかのように受け取れるのであえて放置。
(あと、直し方がわからない)