### PR TITLE
Ticket.statusに対応 in tickets

### DIFF
--- a/pages/tickets/index.vue
+++ b/pages/tickets/index.vue
@@ -2,7 +2,7 @@
   <v-app>
     <v-container name="ticket_container">
       <v-row justify="center" align-content="center">
-        <v-col cols="12" sm="6" lg="6">
+        <v-col cols="12" sm="12" lg="6">
           <!--現在時刻を表示・現在時刻を取得するとv-progress-linearが正常に動作しないため非表示-->
           <!--
             <v-chip v-if="time" label class="ma-1"
@@ -76,7 +76,7 @@
                 isUpNext(
                   new Date(ticketInfo.event.starts_at),
                   new Date(ticketInfo.event.ends_at)
-                )
+                ) && ticketInfo.ticket.status == 'active'
               "
             >
               <v-card-title class="mb-2"
@@ -134,7 +134,7 @@
             </v-card>
           </div>
         </v-col>
-        <v-col cols="12" sm="6" lg="6">
+        <v-col cols="12" sm="12" lg="6">
           <!--取得した整理券一覧-->
           <v-card v-if="tickets.length !== 0">
             <v-card-title
@@ -147,96 +147,102 @@
                 :key="ticketInfo.ticket.id"
                 focusable
               >
-                <v-expansion-panel-header class="pa-3">
-                  <v-list-item>
-                    <v-img
-                      v-if="ticketInfo.group.public_thumbnail_image_url != null"
-                      :src="ticketInfo.group.public_thumbnail_image_url"
-                      max-width="100px"
-                      height="165px"
-                      class="mr-2"
-                      contain
-                    ></v-img>
-                    <div class="ma-2">
-                      <!--取得した整理券の情報を表示-->
-                      <v-list-item-subtitle
-                        >{{ dateFormatter(ticketInfo.event.starts_at) }}
-                        {{ ticketInfo.event.eventname }}</v-list-item-subtitle
-                      >
-                      <v-list-item-title class="text-h7">
-                        {{ ticketInfo.group.title }}
-                      </v-list-item-title>
-                      <v-list-item-subtitle>
-                        {{ ticketInfo.group.groupname }}</v-list-item-subtitle
-                      >
-                      <v-list-item-subtitle
-                        class="mt-2 grey--text text--darken-2"
-                      >
-                        <span class="text-h5"
-                          ><v-icon>mdi-clock-time-nine</v-icon
-                          >{{ timeFormatter(ticketInfo.event.starts_at) }}</span
-                        >
-                        -{{ timeFormatter(ticketInfo.event.ends_at) }}
-                      </v-list-item-subtitle>
-                      <v-list-item-subtitle
-                        class="mb-2 grey--text text--darken-2"
-                      >
-                        <span class="text-h5"
-                          ><v-icon>mdi-account-supervisor</v-icon
-                          >{{ ticketInfo.ticket.person }}</span
-                        >人
-                      </v-list-item-subtitle>
-
-                      <!--整理券の状況を「開場前」（開演20分前まで），「開場中」（開演20分前から終演），「公演終了」（終演以降）に分けて表示-->
-                      <v-chip
+                <div v-if="ticketInfo.ticket.status == 'active'">
+                  <v-expansion-panel-header class="pa-3">
+                    <v-list-item>
+                      <v-img
                         v-if="
-                          isUpNext(
-                            new Date(ticketInfo.event.starts_at),
-                            new Date(ticketInfo.event.ends_at)
-                          )
+                          ticketInfo.group.public_thumbnail_image_url != null
                         "
-                        color="primary"
-                        outlined
-                        label
-                        ><v-icon>mdi-theater</v-icon>開場中</v-chip
-                      >
-                      <v-chip
-                        v-else-if="isUsed(new Date(ticketInfo.event.ends_at))"
-                        color="error"
-                        outlined
-                        label
-                        ><v-icon>mdi-check</v-icon>公演終了</v-chip
-                      >
-                      <v-chip v-else color="green" outlined label>
-                        <v-icon>mdi-account-clock</v-icon>開場前
-                      </v-chip>
-                    </div>
-                  </v-list-item>
-                </v-expansion-panel-header>
-                <v-expansion-panel-content class="pa-1">
-                  <v-divider></v-divider>
-                  <v-card-text>
-                    <p class="text-body-2 grey--text">
-                      ID: {{ ticketInfo.ticket.id }}
-                    </p>
-                  </v-card-text>
-                  <v-card-actions>
-                    <v-btn :href="'/groups/' + ticketInfo.group.id"
-                      >公演詳細
-                    </v-btn>
-                    <v-spacer></v-spacer>
+                        :src="ticketInfo.group.public_thumbnail_image_url"
+                        max-width="100px"
+                        height="165px"
+                        class="mr-2"
+                        contain
+                      ></v-img>
+                      <div class="ma-2">
+                        <!--取得した整理券の情報を表示-->
+                        <v-list-item-subtitle
+                          >{{ dateFormatter(ticketInfo.event.starts_at) }}
+                          {{ ticketInfo.event.eventname }}</v-list-item-subtitle
+                        >
+                        <v-list-item-title class="text-h7">
+                          {{ ticketInfo.group.title }}
+                        </v-list-item-title>
+                        <v-list-item-subtitle>
+                          {{ ticketInfo.group.groupname }}</v-list-item-subtitle
+                        >
+                        <v-list-item-subtitle
+                          class="mt-2 grey--text text--darken-2"
+                        >
+                          <span class="text-h5"
+                            ><v-icon>mdi-clock-time-nine</v-icon
+                            >{{
+                              timeFormatter(ticketInfo.event.starts_at)
+                            }}</span
+                          >
+                          -{{ timeFormatter(ticketInfo.event.ends_at) }}
+                        </v-list-item-subtitle>
+                        <v-list-item-subtitle
+                          class="mb-2 grey--text text--darken-2"
+                        >
+                          <span class="text-h5"
+                            ><v-icon>mdi-account-supervisor</v-icon
+                            >{{ ticketInfo.ticket.person }}</span
+                          >人
+                        </v-list-item-subtitle>
 
-                    <!--終演時刻前の時だけ「整理券をキャンセル」ボタンを表示-->
-                    <v-btn
-                      v-if="!isUsed(new Date(ticketInfo.event.ends_at))"
-                      color="error"
-                      @click="selectCancelTicket(ticketInfo)"
-                    >
-                      <v-icon>mdi-close</v-icon>
-                      整理券をキャンセル
-                    </v-btn>
-                  </v-card-actions>
-                </v-expansion-panel-content>
+                        <!--整理券の状況を「開場前」（開演20分前まで），「開場中」（開演20分前から終演），「公演終了」（終演以降）に分けて表示-->
+                        <v-chip
+                          v-if="
+                            isUpNext(
+                              new Date(ticketInfo.event.starts_at),
+                              new Date(ticketInfo.event.ends_at)
+                            )
+                          "
+                          color="primary"
+                          outlined
+                          label
+                          ><v-icon>mdi-theater</v-icon>開場中</v-chip
+                        >
+                        <v-chip
+                          v-else-if="isUsed(new Date(ticketInfo.event.ends_at))"
+                          color="error"
+                          outlined
+                          label
+                          ><v-icon>mdi-check</v-icon>公演終了</v-chip
+                        >
+                        <v-chip v-else color="green" outlined label>
+                          <v-icon>mdi-account-clock</v-icon>開場前
+                        </v-chip>
+                      </div>
+                    </v-list-item>
+                  </v-expansion-panel-header>
+                  <v-expansion-panel-content class="pa-1">
+                    <v-divider></v-divider>
+                    <v-card-text>
+                      <p class="text-body-2 grey--text">
+                        ID: {{ ticketInfo.ticket.id }}
+                      </p>
+                    </v-card-text>
+                    <v-card-actions>
+                      <v-btn :href="'/groups/' + ticketInfo.group.id"
+                        >公演詳細
+                      </v-btn>
+                      <v-spacer></v-spacer>
+
+                      <!--終演時刻前の時だけ「整理券をキャンセル」ボタンを表示-->
+                      <v-btn
+                        v-if="!isUsed(new Date(ticketInfo.event.ends_at))"
+                        color="error"
+                        @click="selectCancelTicket(ticketInfo)"
+                      >
+                        <v-icon>mdi-close</v-icon>
+                        整理券をキャンセル
+                      </v-btn>
+                    </v-card-actions>
+                  </v-expansion-panel-content>
+                </div>
               </v-expansion-panel>
             </v-expansion-panels>
           </v-card>

--- a/types/quaint.ts
+++ b/types/quaint.ts
@@ -49,5 +49,5 @@ export type Ticket = {
   person: number
   id: string
   created_at: string
-  is_used: boolean
+  status: string
 }


### PR DESCRIPTION
# ※ブランチをdevelopから切り直して再PR．

表題の通り．
# 変更点
- https://github.com/hibiya-itchief/quaint-api/pull/119
の変更にフロントエンドを対応させた．

# 改善が必要（Issue立てて将来的に誰かにお願いしたい）
## ①キャンセル済みチケット表示について
- キャンセル済みのチケットを同一ページから見られるようにしたい．
- イメージは，タブで「有効な整理券」「キャンセル済み」を選択できる．

## ②開場ステータスバッジについて
以下のバッジ：
- 「開場前」（開場20分前まで）
- 「開場中」（開場20分前~公演終了時刻）
- 「公演終了」（公演終了時刻~）
は時間で管理してる，当日の公演スケジュール変更に対応できるよう，APIと連動させて柔軟に対応させたい（設計は未検討）．
<img width="666" alt="image" src="https://github.com/hibiya-itchief/quaint-app/assets/67095865/aeae95ab-928a-4f9d-a954-0506a61cb30b">