### PR TITLE
/login ログインボタンを外にはみ出さないように

### DIFF
--- a/pages/login.vue
+++ b/pages/login.vue
@@ -20,8 +20,14 @@
             ><br />下記の「一般向け整理券配布方法」をご覧ください。
           </p>
           <v-divider class="my-3"></v-divider>
-          <v-btn class="light-blue darken-4 my-3" block dark @click="loginAd()">
-            本校生徒・先生方・保護者の方はこちらから
+          <v-btn
+            height="72"
+            class="light-blue darken-4 my-3"
+            block
+            dark
+            @click="loginAd()"
+          >
+            本校生徒・保護者の方と<br />先生方はこちらから
           </v-btn>
           <p align="center" class="text-caption">
             学校から配布されているMicrosoftアカウント(「@metro.ed.jp」で終わるもの)でログインしてください


### PR DESCRIPTION
* #334 

２行に分ける際にテキスト部分の縦の長さがそのまま２倍になったので、ボタンの縦の長さもそのまま２倍にして比率を保ちました
px数で比例式立ててもちゃんと同じ比率になりました

![image](https://github.com/hibiya-itchief/quaint-app/assets/128669695/0207cddd-8d83-4a7e-9a18-8fcf20c293b7)
