### PR TITLE
/_groupId 観劇予約パネル表示の暫定更新

### DIFF
--- a/pages/groups/_groupId/index.vue
+++ b/pages/groups/_groupId/index.vue
@@ -150,7 +150,7 @@
         </v-col>
         <v-col cols="12" sm="6" lg="4">
           <!--公演時間の選択-->
-          <v-card class="pa-2">
+          <v-card v-if="!IsNotClassroom(group)" class="pa-2">
             <v-card-title>
               <v-icon>mdi-ticket</v-icon>
               観劇予約
@@ -544,6 +544,18 @@ export default Vue.extend({
     },
     checkTakenTickets(index: number) {
       return this.listTakenTickets[index]
+    },
+    IsNotClassroom(group: Group) {
+      for (let i = 0; i < group.tags.length; i++) {
+        if (
+          group.tags[i].tagname === 'Hebe' ||
+          group.tags[i].tagname === '外部団体' ||
+          group.tags[i].tagname === '部活動'
+        ) {
+          return true
+        }
+      }
+      return false
     },
 
     //  未ログイン状態では全ての公演，ログインしている状態ではユーザ属性に合った公演のみが表示されるようにするmethod


### PR DESCRIPTION
* #355 

とりあえず暫定的に、Hebe、外部団体、部活動、のいずれかのタグを持っていると観劇予約パネルが表示されなくなります
本当はクラス劇でないのならという条件にしたかったんですが、それだと開発環境が全部表示されなくなるので…