### PR TITLE
/groupsお気に入り(ブックマーク)機能の調整

### DIFF
--- a/pages/groups/_groupId/index.vue
+++ b/pages/groups/_groupId/index.vue
@@ -86,14 +86,14 @@
                 </div>
               </div>
               <v-btn
-                v-if="IsFavorite(group)"
+                v-if="is_bookmarked"
                 icon
-                class="pink--text"
-                @click="removeFavorite(group)"
-                ><v-icon>mdi-heart</v-icon></v-btn
+                color="sairai"
+                @click="removeBookmark(group.id)"
+                ><v-icon>mdi-bookmark</v-icon></v-btn
               >
-              <v-btn v-else icon @click="addFavorite(group)"
-                ><v-icon>mdi-heart-outline</v-icon></v-btn
+              <v-btn v-else icon @click="addBookmark(group.id)"
+                ><v-icon>mdi-bookmark-outline</v-icon></v-btn
               >
             </v-card-actions>
 
@@ -379,7 +379,8 @@ type Data = {
   ticket_person: number
   person_labels: any[]
   person_icons: any[]
-  displayFavorite: number
+  nowloading: boolean
+  is_bookmarked: boolean
   listStock: number[]
   listTakenTickets: number[]
   view_count: number | string
@@ -430,7 +431,8 @@ export default Vue.extend({
       dialog: false,
       success_snackbar_link: undefined,
       error_snackbar_link: undefined,
-      displayFavorite: 0,
+      nowloading: true,
+      is_bookmarked: false,
       listStock: [],
       listTakenTickets: [],
       view_count: '...',
@@ -522,32 +524,29 @@ export default Vue.extend({
       return this.$quaintUserRole(val.target, this.$auth.user)
     })
   },
+
+  mounted() {
+    for (let i = 0; i < localStorage.length; i++) {
+      if (
+        'seiryofes.groups.favorite.' + this.group?.id ===
+        localStorage.key(i)
+      ) {
+        // お気に入りならtrue
+        this.is_bookmarked = true
+        break
+      }
+    }
+    this.nowloading = false
+  },
+
   methods: {
-    IsFavorite(group: Group) {
-      if (this.displayFavorite === 0) {
-        this.displayFavorite = 1
-        return false
-      }
-      if (this.displayFavorite === 2) {
-        return false
-      }
-      if (this.displayFavorite === 3) {
-        return true
-      }
-      for (let i = 0; i < localStorage.length; i++) {
-        if ('seiryofes.groups.favorite.' + group?.id === localStorage.key(i)) {
-          return true
-        }
-      }
-      return false
+    addBookmark(id: string) {
+      localStorage.setItem('seiryofes.groups.favorite.' + id, id)
+      this.is_bookmarked = true
     },
-    addFavorite(group: Group) {
-      localStorage.setItem('seiryofes.groups.favorite.' + group?.id, group?.id)
-      this.displayFavorite = 3
-    },
-    removeFavorite(group: Group) {
-      localStorage.removeItem('seiryofes.groups.favorite.' + group?.id)
-      this.displayFavorite = 2
+    removeBookmark(id: string) {
+      localStorage.removeItem('seiryofes.groups.favorite.' + id)
+      this.is_bookmarked = false
     },
     checkStock(index: number) {
       return this.listStock[index]

--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -77,35 +77,37 @@
               <v-list-item @click="SortGroups('title')">演目名順</v-list-item>
             </v-list>
           </v-menu>
-          <v-icon
-            v-show="display_bookmarks"
-            color="sairai"
-            @click="
-              display_bookmarks = false
-              PushQuery(null, null, undefined, null, null)
-            "
-            >mdi-bookmark-multiple</v-icon
-          >
-          <v-icon
-            v-show="!display_bookmarks"
-            @click="
-              display_bookmarks = true
-              PushQuery(null, null, true, null, null)
-            "
-            >mdi-bookmark-multiple-outline</v-icon
-          >
-          <v-icon
-            v-show="$route.query.r == 'true'"
-            class="arrow-rotate"
-            @click="ReverseGroups()"
-            >mdi-arrow-up</v-icon
-          >
-          <v-icon
-            v-show="$route.query.r != 'true'"
-            class="arrow-rotate"
-            @click="ReverseGroups()"
-            >mdi-arrow-down</v-icon
-          >
+          <div v-if="!nowloading" style="display: inline">
+            <v-icon
+              v-show="display_bookmarks"
+              color="sairai"
+              @click="
+                display_bookmarks = false
+                PushQuery(null, null, undefined, null, null)
+              "
+              >mdi-bookmark-multiple</v-icon
+            >
+            <v-icon
+              v-show="!display_bookmarks"
+              @click="
+                display_bookmarks = true
+                PushQuery(null, null, true, null, null)
+              "
+              >mdi-bookmark-multiple-outline</v-icon
+            >
+            <v-icon
+              v-show="$route.query.r == 'true'"
+              class="arrow-rotate"
+              @click="ReverseGroups()"
+              >mdi-arrow-up</v-icon
+            >
+            <v-icon
+              v-show="$route.query.r != 'true'"
+              class="arrow-rotate"
+              @click="ReverseGroups()"
+              >mdi-arrow-down</v-icon
+            >
+          </div>
         </v-col>
 
         <v-col class="my-0 py-0" cols="12">
@@ -205,6 +207,13 @@
             </div>
           </v-card>
         </v-col>
+        <p
+          v-show="!nowloading && display_bookmarks"
+          class="mt-10"
+          style="text-align: center"
+        >
+          団体の詳細ページでブックマークを追加することができます。
+        </p>
       </v-row>
     </v-container>
   </v-app>

--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -161,7 +161,7 @@
                 ></v-img>
                 <!--</v-avatar>-->
               </div>
-              <div class="px-1 text-truncate">
+              <div class="px-1 text-truncate" style="width: 100%;">
                 <v-card-title class="pb-2 text-truncate">
                   {{ group.title }}
                 </v-card-title>
@@ -184,6 +184,8 @@
                       {{ tag.tagname }}
                     </v-chip>
                   </v-chip-group>
+                  <v-spacer />
+                  <v-icon>mdi-bookmark-outline</v-icon>
                 </v-card-actions>
               </div>
             </div>

--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -190,25 +190,7 @@
                     </v-chip>
                   </v-chip-group>
                   <v-spacer />
-                  <v-icon
-                    v-show="!FilterBookmarks(group)"
-                    color="sairai"
-                    @click.stop="
-                      localStorage.setItem(
-                        'seiryofes.groups.favorite.' + group.id,
-                        group.id
-                      )
-                    "
-                    >mdi-bookmark-outline</v-icon
-                  >
-                  <v-icon
-                    v-show="FilterBookmarks(group)"
-                    color="sairai"
-                    @click.stop="
-                      localStorage.removeItem(
-                        'seiryofes.groups.favorite.' + group.id
-                      )
-                    "
+                  <v-icon v-if="FilterBookmarks(group.id)" color="sairai"
                     >mdi-bookmark</v-icon
                   >
                 </v-card-actions>
@@ -426,11 +408,11 @@ export default Vue.extend({
       }
     }, // tag全体（{id:hogehoge, tagname:honyohonyo}の形）を用いると，tagが一致している判定がうまく行えなかったので，idを用いてtagの一致を判定している
 
-    FilterBookmarks(group: Group) {
+    FilterBookmarks(id: string) {
       // お気に入りならtrue
       if (this.nowloading === true) return false
       for (let i = 0; i < localStorage.length; i++) {
-        if ('seiryofes.groups.favorite.' + group.id === localStorage.key(i)) {
+        if ('seiryofes.groups.favorite.' + id === localStorage.key(i)) {
           return true
         }
       }

--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -7,6 +7,7 @@
             v-model="search_query"
             solo
             label="検索"
+            color="sairai"
             prepend-inner-icon="mdi-magnify"
             @input="SearchGroups()"
             @blur="

--- a/pages/groups/index.vue
+++ b/pages/groups/index.vue
@@ -207,14 +207,14 @@
             </div>
           </v-card>
         </v-col>
-        <p
-          v-show="!nowloading && display_bookmarks"
-          class="mt-10"
-          style="text-align: center"
-        >
-          団体の詳細ページでブックマークを追加することができます。
-        </p>
       </v-row>
+      <p
+        v-show="!nowloading && display_bookmarks"
+        class="mt-10"
+        style="text-align: center"
+      >
+        団体の詳細ページでブックマークを追加することができます。
+      </p>
     </v-container>
   </v-app>
 </template>


### PR DESCRIPTION
* #193 
* #237 
* #357 

結局、/groupsから追加する機能を実装するのはかなり骨折り事業であることがわかり、
アイコンだけに留めました

結構変更箇所が多いので念入りなreviewをおねがいします

## mountedまで検索バーの下は表示しないように
![Screen Shot 2023-09-02 at 23 06 25](https://github.com/hibiya-itchief/quaint-app/assets/128669695/48734292-f7b7-4062-b7c4-4328fe364c49)
## ブックマーク団体かどうかだけ表示するように
![Screen Shot 2023-09-02 at 23 07 07](https://github.com/hibiya-itchief/quaint-app/assets/128669695/5228fe37-0826-4980-8ce0-0faefe0d2929)
デザインが好きという理由が導入の原動力
## ブックマーク絞り込み時の表示
![Screen Shot 2023-09-02 at 23 07 12](https://github.com/hibiya-itchief/quaint-app/assets/128669695/9fce63c9-ef11-4415-8188-846fa8d6ffe9)
## ブックマークと検索で絞り込み中の表示
![Screen Shot 2023-09-02 at 23 07 27](https://github.com/hibiya-itchief/quaint-app/assets/128669695/b883840c-8a24-47ff-a00d-8a1bdbe06d42)
タグと違いいつでもブックマーク絞り込みが可能
## 団体の詳細ページもハートからブックマークに
![Screen Shot 2023-09-02 at 23 07 50](https://github.com/hibiya-itchief/quaint-app/assets/128669695/bffa8a5a-e4a3-4125-9bf7-ec202c5259d7)
