### PR TITLE
fix: add hamburger-menu background

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -284,10 +284,11 @@ export default Vue.extend({
 
 .hamburgermenu {
   position: relative; /* ボタン内側の基点となるためrelativeを指定 */
+  background: #fff;
   cursor: pointer;
   width: 50px;
   height: 50px;
-  border-radius: 5px;
+  border-radius: 0 0 20px;
 }
 
 /* ボタン内側 */


### PR DESCRIPTION
いいデザインが思いつかず。
スマホのスクショを。
![Screen Shot 2023-09-04 at 20 37 36](https://github.com/hibiya-itchief/quaint-app/assets/128669695/516b09e5-bf4f-4e5d-b0e1-46d5366b8e6a)
![Screen Shot 2023-09-04 at 20 37 58](https://github.com/hibiya-itchief/quaint-app/assets/128669695/e7437eb6-c7fd-4376-a386-cc83c43ffeab)
このように白背景では擬態します
（枠線をつけなかったのは、ハンバーガーを押してメニューを出したときに枠線を消す処理を実装するほど枠線は大事ではないと判断したから）
![Screen Shot 2023-09-04 at 20 37 48](https://github.com/hibiya-itchief/quaint-app/assets/128669695/32ce3be7-ca2c-4513-8b06-05f73b7d6f9e)
