### PR TITLE
/_groupId 公演を始まる順で表示

### DIFF
--- a/pages/groups/_groupId/index.vue
+++ b/pages/groups/_groupId/index.vue
@@ -497,6 +497,13 @@ export default Vue.extend({
           )
         )
       }
+      // 公演の始まる順に。時間外なら下へ
+      this.events.sort((x: Event, y: Event) => {
+        return x.starts_at > y.starts_at ? 1 : -1
+      })
+      this.events.sort((i: Event) => {
+        return !this.isAvailable(i) ? 1 : -1
+      })
 
       Promise.all(getTicketsInfo).then((ticketsInfo) => {
         for (let i = 0; i < ticketsInfo.length; i++) {


### PR DESCRIPTION
![image](https://github.com/hibiya-itchief/quaint-app/assets/128669695/7ee4a583-cd93-4050-988b-fbdf48932336)
(サマーウォーズ)

実際は最大１つか２つが同時に配布中になりえる、はず