### PR TITLE
fix: add contain in /_groupId

### DIFF
--- a/pages/groups/_groupId/index.vue
+++ b/pages/groups/_groupId/index.vue
@@ -12,6 +12,7 @@
             <v-img
               v-if="group.public_thumbnail_image_url != null"
               max-height="500px"
+              contain
               :src="group.public_thumbnail_image_url"
             ></v-img>
             <v-img


### PR DESCRIPTION
containを追加
現行では、スマホ表示は割とcontainなくても大丈夫なんですけど、PCで、特に15R,26Rなんかはcontainないと厳しい表示になってます