### PR TITLE
/edit リンクに飛べるように、Hebe等では公演を編集できないように

### DIFF
--- a/pages/groups/_groupId/edit/index.vue
+++ b/pages/groups/_groupId/edit/index.vue
@@ -635,7 +635,7 @@
               </v-card-actions>
             </div>
           </v-card>
-          <v-dialog v-model="delete_group_dialog">
+          <v-dialog v-model="delete_group_dialog" max-width="500">
             <v-card>
               <v-card-title>本当にこの団体を削除しますか?</v-card-title>
               <v-card-text>この操作は取り消せません</v-card-text>

--- a/pages/groups/_groupId/edit/index.vue
+++ b/pages/groups/_groupId/edit/index.vue
@@ -50,10 +50,12 @@
               <a class="mx-0 my-2 pa-0 text-body-2">編集できません</a>
             </v-card-title>
             <v-card-text class="ma-0 pa-0">
-              <span class="mx-0 my-2 pa-0 text-body-1"
+              <NuxtLink
+                class="grey--text text--darken-2 mx-0 my-2 pa-0 text-body-1"
+                :to="`/groups/${group?.id}`"
                 ><span class="grey--text text--darken-2"
                   >https://{{ hostname }}/groups/</span
-                >{{ group?.id }}</span
+                >{{ group?.id }}</NuxtLink
               >
             </v-card-text>
           </v-card>

--- a/pages/groups/_groupId/edit/index.vue
+++ b/pages/groups/_groupId/edit/index.vue
@@ -508,7 +508,11 @@
             </div>
           </v-card>
 
-          <v-card v-show="true" class="mx-1 my-1 px-2 py-2" elevation="1">
+          <v-card
+            v-if="!IsNotClassroom(group)"
+            class="mx-1 my-1 px-2 py-2"
+            elevation="1"
+          >
             <v-card-title class="ma-0 pa-0">
               <p
                 class="mx-0 my-1 pa-0 grey--text text--darken-2 text-subtitle-2"
@@ -846,6 +850,18 @@ export default Vue.extend({
     }
   },
   methods: {
+    IsNotClassroom(group: Group) {
+      for (let i = 0; i < group.tags.length; i++) {
+        if (
+          group.tags[i].tagname === 'Hebe' ||
+          group.tags[i].tagname === '外部団体' ||
+          group.tags[i].tagname === '部活動'
+        ) {
+          return true
+        }
+      }
+      return false
+    },
     DateFormatter(inputDate: string) {
       const d = new Date(inputDate)
       return (


### PR DESCRIPTION
* 団体ID(ページのURL)をハイパーリンクに
* Hebe等では公演を編集するメニューが出ないように
* 団体削除dialogのサイズを調整

団体削除ボタンはすでにAdmin以外表示されないようになってました
![Screenshot 2023-09-10 at 21-46-01 日比谷高校星陵祭2023公式サイト](https://github.com/hibiya-itchief/quaint-app/assets/128669695/df514ff6-5283-42ca-b3f4-76a8ab13c903)
