### PR TITLE
/data 正しいソート順に など

### DIFF
--- a/pages/groups/_groupId/data/index.vue
+++ b/pages/groups/_groupId/data/index.vue
@@ -9,7 +9,7 @@
           <v-card-title class="text-h5">
             <v-icon class="mx-1" color="blue-grey"
               >mdi-ticket-confirmation</v-icon
-            >{{ group?.groupname }}
+            >{{ group.groupname }}
             <span class="mx-1 grey--text text-subtitle-1"
               >整理券の残席状況</span
             >
@@ -51,21 +51,21 @@
                     >
                     <v-btn
                       v-else-if="
-                        checkTakenTickets(index) / checkStock(index) < 0.8
+                        checkTakenTickets(index) / checkStock(index) < 0.5
                       "
                       color="green"
                       outlined
                       >配布中<v-icon>mdi-circle-double</v-icon></v-btn
                     >
-                    <!--8割以上で黄色になる-->
+                    <!--5割以上で黄色になる-->
                     <v-btn
                       v-else-if="
-                        checkTakenTickets(index) / checkStock(index) >= 0.8 &&
+                        checkTakenTickets(index) / checkStock(index) >= 0.5 &&
                         checkTakenTickets(index) < checkStock(index)
                       "
                       color="orange"
                       outlined
-                      >僅少<v-icon>mdi-triangle-outline</v-icon></v-btn
+                      >残りわずか<v-icon>mdi-triangle-outline</v-icon></v-btn
                     >
                     <v-btn
                       v-else-if="checkTakenTickets(index) >= checkStock(index)"
@@ -77,7 +77,7 @@
                   </div>
                 </v-card>
                 <span class="ma-3"
-                  >満席率：{{ checkTakenTickets(index) ?? '-' }} /
+                  >取得率：{{ checkTakenTickets(index) ?? '-' }} /
                   {{ checkStock(index) ?? '-' }}
                 </span>
               </v-card>
@@ -110,6 +110,19 @@ export default Vue.extend({
   name: 'IndivisualGroupPageData',
   async asyncData({ params, $axios, payload }): Promise<Partial<Data>> {
     const events = await $axios.$get('/groups/' + params.groupId + '/events')
+    events.sort((i: Event) => {
+      return i.target === 'paper' ? 1 : -1
+    })
+    events.sort((x: Event, y: Event) => {
+      return x.starts_at > y.starts_at ? 1 : -1
+    })
+    // 下はisAvailableと同じ処理
+    events.sort((i: Event) => {
+      return new Date() > new Date(i.sell_starts) &&
+        new Date(i.sell_ends) > new Date()
+        ? -1
+        : 1
+    })
 
     if (payload !== undefined) {
       return { group: payload, events }

--- a/pages/groups/_groupId/edit/index.vue
+++ b/pages/groups/_groupId/edit/index.vue
@@ -7,7 +7,7 @@
             <v-icon>mdi-chevron-left</v-icon>
           </v-btn>
           <h2 class="mx-1 px-0">
-            <v-icon color="blue-grey">mdi-pencil</v-icon>{{ group?.groupname }}
+            <v-icon color="blue-grey">mdi-pencil</v-icon>{{ group.groupname }}
             <span class="grey--text text-subtitle-1">団体情報の編集</span>
           </h2>
           <p class="pa-2">

--- a/pages/groups/_groupId/index.vue
+++ b/pages/groups/_groupId/index.vue
@@ -404,6 +404,19 @@ export default Vue.extend({
   auth: false,
   async asyncData({ params, $axios, payload }): Promise<Partial<Data>> {
     const events = await $axios.$get('/groups/' + params.groupId + '/events')
+    events.sort((i: Event) => {
+      return i.target === 'paper' ? 1 : -1
+    })
+    events.sort((x: Event, y: Event) => {
+      return x.starts_at > y.starts_at ? 1 : -1
+    })
+    // 下はisAvailableと同じ処理
+    events.sort((i: Event) => {
+      return new Date() > new Date(i.sell_starts) &&
+        new Date(i.sell_ends) > new Date()
+        ? -1
+        : 1
+    })
 
     if (payload !== undefined) {
       return { group: payload, events }
@@ -498,13 +511,6 @@ export default Vue.extend({
           )
         )
       }
-      // 公演の始まる順に。時間外なら下へ
-      this.events.sort((x: Event, y: Event) => {
-        return x.starts_at > y.starts_at ? 1 : -1
-      })
-      this.events.sort((i: Event) => {
-        return !this.isAvailable(i) ? 1 : -1
-      })
 
       Promise.all(getTicketsInfo).then((ticketsInfo) => {
         for (let i = 0; i < ticketsInfo.length; i++) {

--- a/pages/groups/_groupId/index.vue
+++ b/pages/groups/_groupId/index.vue
@@ -226,7 +226,7 @@
                     style="font-weight: bold"
                     >配布中<v-icon>mdi-circle-double</v-icon></v-btn
                   >
-                  <!--8割以上で黄色になる-->
+                  <!--5割以上で黄色になる-->
                   <v-btn
                     v-else-if="
                       checkTakenTickets(index) / checkStock(index) >= 0.5 &&

--- a/pages/groups/_groupId/index.vue
+++ b/pages/groups/_groupId/index.vue
@@ -45,7 +45,10 @@
                 団体情報を編集
               </v-btn>
             </v-card-actions>
-            <v-card-actions v-if="editable == true" class="py-1">
+            <v-card-actions
+              v-if="editable == true && !IsNotClassroom(group)"
+              class="py-1"
+            >
               <v-btn
                 color="blue-grey"
                 dark


### PR DESCRIPTION
test13rにて、時系列学校(target: school)1→学校2となるように学校及び紙(target: paper)を用意

コード的には正しいソート順になったはずだが、実際に動かすとたまに2→2→1→1になることがある
開発環境特有のバグの可能性がある

オンライン→紙という順番、配布中→配布時間外という順番、の２原則はずっと正しいまま。