### PR TITLE
/edit タグ追加をadminだけに制限

### DIFF
--- a/pages/groups/_groupId/edit/index.vue
+++ b/pages/groups/_groupId/edit/index.vue
@@ -442,7 +442,11 @@
             </div>
           </v-card>
 
-          <v-card class="mx-1 my-1 px-2 py-2" elevation="1">
+          <v-card
+            v-show="$auth.user?.groups?.includes(userGroups.admin)"
+            class="mx-1 my-1 px-2 py-2"
+            elevation="1"
+          >
             <v-card-title class="ma-0 pa-0">
               <p
                 class="mx-0 my-1 pa-0 grey--text text--darken-2 text-subtitle-2"


### PR DESCRIPTION
今年は、タグは初期設定から変えない方針で。
今、タグが消えちゃったり、別のタグを追加しちゃってたりすることがあるので。