### PR TITLE
/_groupId 再読み込みでちゃんと再読み込みされるように

### DIFF
--- a/pages/groups/_groupId/data/index.vue
+++ b/pages/groups/_groupId/data/index.vue
@@ -46,7 +46,11 @@
                   <v-spacer></v-spacer>
                   <div class="my-auto mx-2">
                     <!--ここから配布ステータスの条件分岐-->
-                    <v-btn v-if="!isAvailable(event)" color="grey" outlined
+                    <v-btn
+                      v-if="!isAvailable(event)"
+                      color="grey"
+                      outlined
+                      style="font-weight: bold"
                       >時間外<v-icon>mdi-cancel</v-icon></v-btn
                     >
                     <v-btn
@@ -55,6 +59,7 @@
                       "
                       color="green"
                       outlined
+                      style="font-weight: bold"
                       >配布中<v-icon>mdi-circle-double</v-icon></v-btn
                     >
                     <!--5割以上で黄色になる-->
@@ -65,12 +70,14 @@
                       "
                       color="orange"
                       outlined
+                      style="font-size: 80%; font-weight: bold"
                       >残りわずか<v-icon>mdi-triangle-outline</v-icon></v-btn
                     >
                     <v-btn
                       v-else-if="listTakenTickets[index] >= listStock[index]"
                       color="red"
                       outlined
+                      style="font-weight: bold"
                       >完売<v-icon>mdi-close</v-icon></v-btn
                     >
                     <!--ここまで配布ステータスの条件分岐-->

--- a/pages/groups/_groupId/data/index.vue
+++ b/pages/groups/_groupId/data/index.vue
@@ -51,7 +51,7 @@
                     >
                     <v-btn
                       v-else-if="
-                        checkTakenTickets(index) / checkStock(index) < 0.5
+                        listTakenTickets[index] / listStock[index] < 0.5
                       "
                       color="green"
                       outlined
@@ -60,15 +60,15 @@
                     <!--5割以上で黄色になる-->
                     <v-btn
                       v-else-if="
-                        checkTakenTickets(index) / checkStock(index) >= 0.5 &&
-                        checkTakenTickets(index) < checkStock(index)
+                        listTakenTickets[index] / listStock[index] >= 0.5 &&
+                        listTakenTickets[index] < listStock[index]
                       "
                       color="orange"
                       outlined
                       >残りわずか<v-icon>mdi-triangle-outline</v-icon></v-btn
                     >
                     <v-btn
-                      v-else-if="checkTakenTickets(index) >= checkStock(index)"
+                      v-else-if="listTakenTickets[index] >= listStock[index]"
                       color="red"
                       outlined
                       >完売<v-icon>mdi-close</v-icon></v-btn
@@ -77,8 +77,8 @@
                   </div>
                 </v-card>
                 <span class="ma-3"
-                  >取得率：{{ checkTakenTickets(index) ?? '-' }} /
-                  {{ checkStock(index) ?? '-' }}
+                  >取得率：{{ listTakenTickets[index] ?? '-' }} /
+                  {{ listStock[index] ?? '-' }}
                 </span>
               </v-card>
             </v-col>
@@ -103,8 +103,8 @@ type Data = {
   }
   group: Group | undefined
   events: Event[]
-  listStock: string[]
-  listTakenTickets: string[]
+  listStock: number[]
+  listTakenTickets: number[]
 }
 export default Vue.extend({
   name: 'IndivisualGroupPageData',
@@ -124,12 +124,29 @@ export default Vue.extend({
         : 1
     })
 
-    if (payload !== undefined) {
-      return { group: payload, events }
-    }
-    const group = await $axios.$get('/groups/' + params.groupId)
+    // nuxt generate時はpayloadを代入
+    const group = payload ?? (await $axios.$get('/groups/' + params.groupId))
 
-    return { group, events }
+    // 各ticketsを取得
+    if (events.length !== 0) {
+      const getTicketsInfo = []
+      for (let i = 0; i < events.length; i++) {
+        getTicketsInfo.push(
+          $axios.$get(`/groups/${group.id}/events/${events[i].id}/tickets`)
+        )
+      }
+      const listStock: number[] = []
+      const listTakenTickets: number[] = []
+      Promise.all(getTicketsInfo).then((ticketsInfo) => {
+        for (let i = 0; i < ticketsInfo.length; i++) {
+          listStock.push(ticketsInfo[i].stock)
+          listTakenTickets.push(ticketsInfo[i].taken_tickets)
+        }
+      })
+      return { group, events, listStock, listTakenTickets }
+    } else {
+      return { group, events }
+    }
   },
   data(): Data {
     return {
@@ -154,26 +171,6 @@ export default Vue.extend({
     }
   },
   async created() {
-    if (this.events.length !== 0) {
-      const getTicketsInfo = []
-      for (let i = 0; i < this.events.length; i++) {
-        getTicketsInfo.push(
-          this.$axios.$get(
-            '/groups/' +
-              this.group?.id +
-              '/events/' +
-              this.events[i].id +
-              '/tickets'
-          )
-        )
-      }
-      Promise.all(getTicketsInfo).then((ticketsInfo) => {
-        for (let i = 0; i < ticketsInfo.length; i++) {
-          this.listStock.push(ticketsInfo[i].stock)
-          this.listTakenTickets.push(ticketsInfo[i].taken_tickets)
-        }
-      })
-    }
     if (
       !(this.$auth.user?.groups as string[]).includes(this.userGroups.admin)
     ) {
@@ -193,13 +190,6 @@ export default Vue.extend({
     }
   },
   methods: {
-    checkStock(index: number) {
-      return this.listStock[index]
-    },
-    checkTakenTickets(index: number) {
-      return this.listTakenTickets[index]
-    },
-
     isToday(
       inputSellStarts: string,
       inputSellEnds: string,

--- a/pages/groups/_groupId/index.vue
+++ b/pages/groups/_groupId/index.vue
@@ -194,7 +194,7 @@
                 class="ma-2 d-flex"
                 :disabled="
                   !isAvailable(event) ||
-                  checkTakenTickets(index) >= checkStock(index)
+                  listTakenTickets[index] >= listStock[index]
                 "
                 @click.stop="selectEvent(event)"
               >
@@ -224,9 +224,7 @@
                     >時間外<v-icon>mdi-cancel</v-icon></v-btn
                   >
                   <v-btn
-                    v-else-if="
-                      checkTakenTickets(index) / checkStock(index) < 0.5
-                    "
+                    v-else-if="listTakenTickets[index] / listStock[index] < 0.5"
                     color="green"
                     outlined
                     style="font-weight: bold"
@@ -235,8 +233,8 @@
                   <!--5割以上で黄色になる-->
                   <v-btn
                     v-else-if="
-                      checkTakenTickets(index) / checkStock(index) >= 0.5 &&
-                      checkTakenTickets(index) < checkStock(index)
+                      listTakenTickets[index] / listStock[index] >= 0.5 &&
+                      listTakenTickets[index] < listStock[index]
                     "
                     color="orange"
                     outlined
@@ -244,7 +242,7 @@
                     >残りわずか<v-icon>mdi-triangle-outline</v-icon></v-btn
                   >
                   <v-btn
-                    v-else-if="checkTakenTickets(index) >= checkStock(index)"
+                    v-else-if="listTakenTickets[index] >= listStock[index]"
                     color="red"
                     outlined
                     style="font-weight: bold"
@@ -437,12 +435,29 @@ export default Vue.extend({
         : 1
     })
 
-    if (payload !== undefined) {
-      return { group: payload, events }
-    }
-    const group = await $axios.$get('/groups/' + params.groupId)
+    // nuxt generate時はpayloadを代入
+    const group = payload ?? (await $axios.$get('/groups/' + params.groupId))
 
-    return { group, events }
+    // 各ticketsを取得
+    if (events.length !== 0) {
+      const getTicketsInfo = []
+      for (let i = 0; i < events.length; i++) {
+        getTicketsInfo.push(
+          $axios.$get(`/groups/${group.id}/events/${events[i].id}/tickets`)
+        )
+      }
+      const listStock: number[] = []
+      const listTakenTickets: number[] = []
+      Promise.all(getTicketsInfo).then((ticketsInfo) => {
+        for (let i = 0; i < ticketsInfo.length; i++) {
+          listStock.push(ticketsInfo[i].stock)
+          listTakenTickets.push(ticketsInfo[i].taken_tickets)
+        }
+      })
+      return { group, events, listStock, listTakenTickets }
+    } else {
+      return { group, events }
+    }
   },
   data(): Data {
     return {
@@ -517,28 +532,6 @@ export default Vue.extend({
     }
   },
   created() {
-    if (this.events.length !== 0) {
-      const getTicketsInfo = []
-      for (let i = 0; i < this.events.length; i++) {
-        getTicketsInfo.push(
-          this.$axios.$get(
-            '/groups/' +
-              this.group?.id +
-              '/events/' +
-              this.events[i].id +
-              '/tickets'
-          )
-        )
-      }
-
-      Promise.all(getTicketsInfo).then((ticketsInfo) => {
-        for (let i = 0; i < ticketsInfo.length; i++) {
-          this.listStock.push(ticketsInfo[i].stock)
-          this.listTakenTickets.push(ticketsInfo[i].taken_tickets)
-        }
-      })
-    }
-
     // admin権限を持つ もしくは この団体にowner権限を持つユーザーがアクセスするとtrueになりページを編集できる
     // 実際に編集できるかどうかはAPIがJWTで認証するのでここはあくまでフロント側の制御
     if (this.$auth.user?.groups && Array.isArray(this.$auth.user?.groups)) {
@@ -593,12 +586,6 @@ export default Vue.extend({
     removeBookmark(id: string) {
       localStorage.removeItem('seiryofes.groups.favorite.' + id)
       this.is_bookmarked = false
-    },
-    checkStock(index: number) {
-      return this.listStock[index]
-    },
-    checkTakenTickets(index: number) {
-      return this.listTakenTickets[index]
     },
     IsNotClassroom(group: Group) {
       for (let i = 0; i < group.tags.length; i++) {

--- a/pages/groups/_groupId/index.vue
+++ b/pages/groups/_groupId/index.vue
@@ -238,7 +238,7 @@
                     "
                     color="orange"
                     outlined
-                    style="font-weight: bold"
+                    style="font-size: 80%; font-weight: bold"
                     >残りわずか<v-icon>mdi-triangle-outline</v-icon></v-btn
                   >
                   <v-btn


### PR DESCRIPTION
・createdのlist〇〇機構をasyncDataに移動
(これによって$nuxt.refreshで更新するように）

・「残りわずか」の文字サイズをちょっと小さくしてスマホでも表示が崩れにくいように

・あとAPIでticketsキャッシュしないようにすれば完全に整理券取得競争が行えるように
（ただし、そうすると配布開始の時にたくさんの人が/ticketsを連打することになるから、まさに負荷がどうなるか…）
