### PR TITLE
Release 1.0.5 のパッチ

### DIFF
--- a/components/CountDown.vue
+++ b/components/CountDown.vue
@@ -9,7 +9,7 @@ export default Vue.extend({
     const ctx = canvas.getContext('2d')
     const img = new Image()
     img.src = '/images/countdown.jpg'
-    const yay = new Date('2023-09-16T00:00:00+09:00')
+    const yay = new Date('2024-09-14T00:00:00+09:00')
     const diff = Math.ceil(
       (yay.getTime() - new Date().getTime()) / (1000 * 60 * 60 * 24)
     ) // ミリ秒を日に変換

--- a/pages/groups/_groupId/index.vue
+++ b/pages/groups/_groupId/index.vue
@@ -33,7 +33,8 @@
                   </v-chip>
                 </v-chip-group>
               </v-card-actions>
-              <v-card-actions style="width: 100%; display: block">
+              <!-- 一時的に映像配信を非表示
+                <v-card-actions style="width: 100%; display: block">
                 <div
                   v-for="link in links"
                   :key="link.id"
@@ -58,6 +59,7 @@
                 >
               </v-card-actions>
               <v-divider></v-divider>
+              -->
               <v-card-actions v-if="editable == true" class="py-1">
                 <v-btn
                   color="blue-grey"


### PR DESCRIPTION
一旦、映像配信を非表示に。

そういえば、バージョン番号の一番下のことをパッチバージョンと呼ぶらしく、ほんとは新規機能追加をマイナーバージョンで統一すべきだったんですかね…
まあ'23は正直新しい機能ずくめでしたのでしょうがないといえばしょうがない