### PR TITLE
Release 1.0.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [lts/*]
+        node: [16.20.0]
 
     steps:
       - name: Checkout 🛎


### PR DESCRIPTION
ログインしているかどうかをチェックする表示が正しく表示されるように。

というのは建前で、実際は現在ちゃんとビルドが行われているか確認するためのRelease。
ビルドが行われていないことに由来するのではないかと思われるバグが報告されているため。