### PR TITLE
Release 1.0.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [lts/*]
+        node: [16.20.0]
 
     steps:
       - name: Checkout 🛎


### PR DESCRIPTION
Nodeのバージョンを落としても治らなかった勝山のリンクが表示されないバグの修正、力業
成功したらうれしい